### PR TITLE
fix(test): 日本語フィールド名でのドット記法アクセスを修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,8 @@ Thumbs.db
 .firebase/
 firebase-debug.log
 firebase-debug.*.log
+firestore-debug.log
+ui-debug.log
+database-debug.log
+pubsub-debug.log
 

--- a/backend/test_game_flow.py
+++ b/backend/test_game_flow.py
@@ -141,7 +141,10 @@ snap = room_ref.get()
 ans_snap = round_ref.collection("answers").get()
 check("全員回答した", len(ans_snap) == len(players), f"{len(ans_snap)}/{len(players)}人")
 check("status=PREDICTING", snap.get("status") == "PREDICTING")
-check("answerCounts 集計正確（はい=3）", snap.get("answerCounts.はい") == counts["はい"],
+# snap.get("answerCounts.はい") のドット記法は ASCII のフィールド名しか解釈できず、
+# 日本語キーだと ValueError になる。辞書ごと取得してキーを引く。
+answer_counts = snap.get("answerCounts") or {}
+check("answerCounts 集計正確（はい=3）", answer_counts.get("はい") == counts["はい"],
       f"はい={counts['はい']}, いいえ={counts['いいえ']}")
 
 # ── TEST 5: 予測送信 + 採点 ───────────────────────────────────


### PR DESCRIPTION
## 概要

`backend/test_game_flow.py` の TEST 5 が `ValueError` で落ちていたのを修正します。

```
ValueError: Path answerCounts.はい not consumed, residue: はい
```

## 原因

Firestore の `DocumentSnapshot.get()` に渡すドット区切りパスは、内部のトークナイザが **ASCII のフィールド名しかパースできません**。日本語キー「はい」でトークナイズに失敗していました。

```python
# NG: ドット記法は日本語キーを解釈できない
snap.get("answerCounts.はい")

# OK: 辞書ごと取得してキーを引く
answer_counts = snap.get("answerCounts") or {}
answer_counts.get("はい")
```

**アプリ本体の不具合ではなく、テストコード側の問題です。** ゲームロジックと Firestore への書き込み自体は正常に動作しています。

## 変更内容

- `backend/test_game_flow.py`: ドット記法をやめ、辞書アクセスに変更
- `.gitignore`: エミュレータが生成するログ（`firestore-debug.log` 等）を追加

## 検証

```
firebase emulators:exec --only firestore,auth "python3 test_game_flow.py"
→ TEST 1〜8 すべて合格
```

| テスト | 内容 |
|---|---|
| TEST 1〜3 | ルーム作成・プレイヤー参加・ゲーム開始 |
| TEST 4 | 回答送信と集計（**本 PR で修正した箇所**） |
| TEST 5 | 予測送信と採点（4人分のスコア計算） |
| TEST 6 | 次ラウンドへの遷移 |
| TEST 7 | 採点ロジック単体（差0/1/2/5以上・0人ぴったり） |
| TEST 8 | ゲーム終了と finalScores 保存 |

あわせて `backend/test_logic.py`（Firestore 非依存のロジック単体テスト）も全合格を確認しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
