### PR TITLE
docs: CLAUDE.md の技術スタックを実態（Firebase）に合わせて更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,11 +13,19 @@
 6. 正解に近い人が高得点→採点・結果表示
 
 ## 技術スタック
-- **フロント**: Android / Kotlin
-- **バックエンド**: Python / AWS Lambda / API Gateway（WebSocket）
-- **DB**: DynamoDB（ルーム・質問・回答・スコア管理）
-- **QRコード**: バックエンド生成 / Android ZXingスキャン
-- **IaC**: Terraform
+
+> 2026-03-20 に **AWS から Firebase へ移行済み**。AWS 実装（Terraform / Lambda / DynamoDB）は
+> `archive/` に退避してあり、現行構成では使用しない。詳細は `docs/architecture.md`（v2.0）。
+
+- **フロント**: Android / Kotlin / Jetpack Compose（Navigation Compose + ViewModel）
+- **バックエンド**: Python 3.12 / Firebase Cloud Functions（HTTPS 関数・us-central1）
+- **DB**: Cloud Firestore（ルーム・プレイヤー・回答・スコア管理）
+- **リアルタイム通信**: Firestore リスナー（onSnapshot）。WebSocket は使わない
+- **QRコード**: Android 側で生成・スキャンとも完結（ZXing）
+- **Web**: Firebase Hosting（招待リンク `web/public/join/`）
+- **IaC**: `backend/firebase.json`（Functions / Firestore / Hosting / Emulator 設定）
+
+パッケージ名: `com.rokusoudo.hitokazu`
 
 ## エージェント構成
 | エージェント | 役割 |
@@ -37,11 +45,44 @@
 POの仕様（docs/）をもとに設計・実装を担当してください。
 バックエンドはbackend/、Androidアプリはandroid/に配置してください。
 
+実装前に `docs/architecture.md` を読むこと。`archive/` の AWS 実装は
+移行前の遺構なので参照しない。
+
 ## ディレクトリ構成
 ```
-hitokazu_game/
-├── CLAUDE.md         # このファイル（プロジェクト共通情報）
-├── docs/             # PO管理：仕様・要件・バックログ
-├── backend/          # エンジニア：Python / Lambda / Terraform
-└── android/          # エンジニア：Kotlin / Androidアプリ
+hitokazu_game/                    # リポジトリ名は qa-count-hit-game
+├── CLAUDE.md                     # このファイル（プロジェクト共通情報）
+├── docs/                         # PO管理：仕様・要件・バックログ
+│   ├── architecture.md           #   システム構成（v2.0 / Firebase）
+│   ├── firebase_setup.md
+│   ├── requirements.md
+│   ├── user_stories.md
+│   └── backlog.md
+├── backend/                      # エンジニア：Firebase
+│   ├── firebase.json             #   Functions / Firestore / Hosting / Emulator
+│   ├── firestore.rules
+│   ├── functions/main.py         #   Cloud Functions 本体
+│   ├── test_logic.py             #   ロジック単体（Firestore 非依存）
+│   ├── test_game_flow.py         #   Emulator 統合テスト
+│   └── test_functions.py         #   ⚠️ 本番 Firestore に直接書き込む
+├── android/                      # エンジニア：Kotlin / Compose
+├── web/                          # Firebase Hosting（招待リンク）
+└── archive/                      # AWS 旧実装（参照のみ・使用しない）
 ```
+
+## テスト実行
+
+```bash
+cd backend
+
+# ロジック単体（依存なし）
+python3 test_logic.py
+
+# Emulator 統合テスト（firebase CLI + Java が必要）
+firebase emulators:exec --only firestore,auth \
+  "FIRESTORE_EMULATOR_HOST=localhost:8080 python3 test_game_flow.py"
+```
+
+⚠️ `test_functions.py` は **本番 Firestore（`hitokazu-game`）に直接書き込む**スクリプト。
+末尾に削除処理はあるが、途中で失敗するとテストデータが本番に残る。
+内容は `test_game_flow.py` とほぼ重複するため、通常は実行しないこと。


### PR DESCRIPTION
## 概要

2026-03-20 に AWS から Firebase へ移行済みですが、**`CLAUDE.md` だけが移行前の記述のまま取り残されていました**（`docs/architecture.md` は v2.0 に更新済み）。

このファイルはエージェントが最初に読む前提情報のため、誤った技術スタックで実装される恐れがあります。

## 修正前後

| 項目 | 修正前（誤） | 修正後（実態） |
|---|---|---|
| バックエンド | AWS Lambda / API Gateway | Firebase Cloud Functions (Python 3.12) |
| DB | DynamoDB | Cloud Firestore |
| リアルタイム通信 | WebSocket | Firestore リスナー（onSnapshot） |
| QRコード | バックエンド生成 | Android 側で生成・スキャンとも完結（ZXing） |
| IaC | Terraform | `backend/firebase.json` |
| Android UI | （記載なし） | Jetpack Compose |

## その他の変更

- ディレクトリ構成を実態に合わせ、`archive/` が AWS 移行前の遺構であること（参照しない）を明記
- テスト実行手順を追加
- **`test_functions.py` が本番 Firestore に直接書き込む**ため通常は実行しない旨を警告として記載
- エンジニアエージェント向けに「実装前に `docs/architecture.md` を読む」旨を追記

## 検証

記載内容を実際のコードと突き合わせて確認しました（**OK=13 / NG=0**）。

- Compose / python312 / us-central1 / パッケージ名 `com.rokusoudo.hitokazu`
- `archive/terraform_aws` の存在、`web/public/join/`、各テストファイルの存在
- ZXing の使用箇所、firebase.json の hosting・emulator 設定
- 現行コード（`backend/`, `android/`）に `boto3` / `dynamodb` / `lambda_handler` が残っていないこと

記載したテストコマンド（`python3 test_logic.py`）が実際に動作することも確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
