### PR TITLE
ci: PRでテスト・Lintを自動実行するCIワークフローを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,104 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  logic-tests:
+    name: ロジック単体テスト
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      # backend/test_logic.py は Firestore に依存しないため追加の依存インストールは不要。
+      # backend/test_functions.py は本番Firestoreに直接書き込むスクリプトのため、
+      # CIでは意図的に実行しない（backend/CLAUDE.md 参照）。
+      - name: Run logic unit tests
+        run: python3 backend/test_logic.py
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install flake8
+        run: pip install flake8
+
+      # 既存コードベースにlint設定がなかったため今回導入。
+      # 1本目: 構文エラー・未定義名などの実害があるものだけを検出して失敗させる。
+      - name: Lint Python (errors)
+        run: |
+          flake8 backend --count --select=E9,F63,F7,F82 \
+            --extend-exclude=backend/functions/venv \
+            --show-source --statistics
+
+      # 2本目: スタイル面は現時点では警告のみ（exit-zero）とし、既存コードを壊さない。
+      - name: Lint Python (style, non-blocking)
+        run: |
+          flake8 backend --count --exit-zero --max-complexity=10 --max-line-length=127 \
+            --extend-exclude=backend/functions/venv \
+            --statistics
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: backend/rules-tests/package-lock.json
+
+      - name: Install rules-tests dependencies
+        run: npm --prefix backend/rules-tests ci
+
+      # backend/rules-tests に lint 設定（lintスクリプト）が追加された場合のみ実行される。
+      # 現時点では未設定のため no-op。
+      - name: Lint JS (rules-tests, if configured)
+        run: npm --prefix backend/rules-tests run lint --if-present
+
+  rules-tests:
+    name: Firestoreルールテスト（Emulator）
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: backend/rules-tests/package-lock.json
+
+      - name: Cache Firebase emulators
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/firebase/emulators
+          key: firebase-emulators-${{ runner.os }}
+
+      - name: Install rules-tests dependencies
+        run: npm --prefix backend/rules-tests ci
+
+      # rules.test.mjs（権限マトリクス24件）+ gameflow.test.mjs（実ゲームフロー8件）= 32件
+      - name: Run Firestore rules tests (emulator)
+        run: npm --prefix backend/rules-tests run test:emulator

--- a/README.md
+++ b/README.md
@@ -115,6 +115,17 @@ npm --prefix rules-tests run test:emulator
 
 > `test_game_flow.py` は firebase-admin SDK を使うため**ルールを迂回**します。ルール変更の影響を確認するときは上記のテストを使ってください。
 
+### CI（自動テスト）
+
+`main` 宛の Pull Request と `main` への push で [`.github/workflows/ci.yml`](.github/workflows/ci.yml) が自動実行されます。
+
+- `backend/test_logic.py`（採点ロジック単体テスト）
+- `backend/rules-tests/`（Firestoreルールテスト・権限マトリクス24件＋実ゲームフロー8件、Firebase Emulator上で実行）
+- lint（Python: flake8）
+
+テストが1件でも失敗するとCIが失敗（レッド）になり、PR上にステータスとして表示されます。
+`test_functions.py` は本番Firestoreに直接書き込むスクリプトのため、CIには含めていません（手動実行のみ）。
+
 詳細は [docs/architecture.md](docs/architecture.md) を参照。
 
 ---


### PR DESCRIPTION
## 概要

.github/workflows/ci.yml を追加し、main 宛の Pull Request と main への push でバックエンドのテスト・lintを自動実行するようにしました。

Closes #13

## 変更内容

- logic-tests ジョブ: python3 backend/test_logic.py（採点ロジック単体テスト・依存インストール不要）
- lint ジョブ:
  - Python: flake8（構文エラー・未定義名などの実害があるもの E9,F63,F7,F82 は必須失敗、既存コードにlint未導入だったためスタイル系は当面 exit-zero で警告のみ）
  - JS: backend/rules-tests に lint スクリプトが将来追加された場合に自動で拾われるよう npm run lint --if-present を仕込み済み（現状は lint 設定が無いため no-op）
- rules-tests ジョブ: Java 17 + Node 20 をセットアップし、npm --prefix backend/rules-tests ci の後 npm --prefix backend/rules-tests run test:emulator でFirestoreルールテスト（権限マトリクス24件＋実ゲームフロー8件＝32件）をEmulator上で実行。~/.cache/firebase/emulators をキャッシュ
- backend/test_functions.py は本番Firestoreに直接書き込むスクリプトのため、意図的にCIから除外（backend/CLAUDE.md の警告どおり）
- README にCI自動実行の記載を追記
- Android ビルド検証は google-services.json が .gitignore 対象でCIから参照できないため、今回のスコープ外（Issue本文どおり）

## 受け入れ基準チェック

- [x] .github/workflows/ci.yml が追加され、main 宛の PR で自動実行される
- [x] backend/test_logic.py が CI 上で実行され、成功する（ローカルで実行確認済み・依存なし）
- [x] backend/rules-tests の 32 件（権限 24 + ゲームフロー 8）が Emulator 上で実行される設定
- [x] テスト失敗時にCIがレッドになりPRにステータス表示される（pythonはテスト失敗時に非ゼロ終了、node --testも失敗時に非ゼロ終了するため、各ジョブのstepが失敗しジョブ・チェック全体が失敗する構造）
- [x] backend/test_functions.py はCIで実行されない
- [x] README のテストの節にCI自動実行の記載あり
- [x] lint ジョブがCIに追加され、PRで自動実行される

## テスト

- [x] python3 backend/test_logic.py をローカル実行し全テスト合格を確認
- [x] flake8 backend --select=E9,F63,F7,F82 --extend-exclude=backend/functions/venv がローカルで0件（exit 0）であることを確認
- [x] ci.yml をYAMLとしてパース可能なことを確認
- [ ] Firebase Emulatorのフル実行（npm --prefix backend/rules-tests ci から test:emulator まで）はローカル環境（WSL経由でWindows側node/npmを参照する構成のため）の制約でフル実行までは確認できず、ワークフローのステップ順序・構文レビューで代替。実行手順自体は既存README/package.jsonの test:emulator スクリプトをそのまま踏襲しています
- [ ] 意図的なテスト失敗によるCIレッド化の実機確認は未実施（上記のとおりロジック上fail検知される構造で説明）
