### PR TITLE
docs: 仕様書を現行 Firebase 実装に合わせて是正し、バックログを Issue へ一本化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,10 @@
 ## 技術スタック
 
 > 2026-03-20 に **AWS から Firebase へ移行済み**。AWS 実装（Terraform / Lambda / DynamoDB）は
-> `archive/` に退避してあり、現行構成では使用しない。詳細は `docs/architecture.md`（v2.0）。
+> `archive/` に退避してあり、現行構成では使用しない。詳細は `docs/architecture.md`（v3.0）。
+>
+> ⚠️ **Cloud Functions は実装済みだが、Android・Web のどちらからも呼び出していない。**
+> クライアントは Firestore を直接読み書きし、採点・フェーズ遷移もクライアント側で行う。
 
 - **フロント**: Android / Kotlin / Jetpack Compose（Navigation Compose + ViewModel）
 - **バックエンド**: Python 3.12 / Firebase Cloud Functions（HTTPS 関数・us-central1）
@@ -30,14 +33,14 @@
 ## エージェント構成
 | エージェント | 役割 |
 |------------|------|
-| POエージェント | 要件定義・仕様策定・バックログ管理 |
+| POエージェント | 要件定義・仕様策定・GitHub Issue の起票と優先度づけ |
 | エンジニアエージェント | 設計・実装・インフラ構築 |
 
 ## POエージェントへの指示
 あなたは「人数当てゲーム」のプロダクトオーナーです。
 このディレクトリ（/home/zakis/hitokazu_game）を作業場所として、
-要件定義・ユーザーストーリー・バックログ管理を担当してください。
-仕様はdocs/ディレクトリにMarkdownで管理してください。
+要件定義・ユーザーストーリーの策定と GitHub Issue の管理を担当してください。
+仕様はdocs/ディレクトリにMarkdownで管理し、バックログは GitHub Issue を正としてください。
 
 ## エンジニアエージェントへの指示
 あなたは「人数当てゲーム」のエンジニアです。
@@ -52,12 +55,11 @@ POの仕様（docs/）をもとに設計・実装を担当してください。
 ```
 hitokazu_game/                    # リポジトリ名は qa-count-hit-game
 ├── CLAUDE.md                     # このファイル（プロジェクト共通情報）
-├── docs/                         # PO管理：仕様・要件・バックログ
-│   ├── architecture.md           #   システム構成（v2.0 / Firebase）
+├── docs/                         # PO管理：仕様・要件（バックログは GitHub Issue が正）
+│   ├── architecture.md           #   システム構成（v3.0 / Firebase）
 │   ├── firebase_setup.md
-│   ├── requirements.md
-│   ├── user_stories.md
-│   └── backlog.md
+│   ├── requirements.md           #   要件定義（v2.0）
+│   └── user_stories.md
 ├── shared/
 │   └── questions.json            #   質問マスタの正本（36問。Issue #16）
 ├── scripts/
@@ -76,7 +78,14 @@ hitokazu_game/                    # リポジトリ名は qa-count-hit-game
 │   └── .../data/questions/Questions.kt  # 質問マスタ（自動生成・直接編集しない）
 ├── web/                          # Firebase Hosting（招待リンク）
 └── archive/                      # AWS 旧実装（参照のみ・使用しない）
+    └── backlog_aws.md            #   AWS 時代のバックログ（凍結。現行は GitHub Issue）
 ```
+
+### バックログの正本は GitHub Issue
+
+プロダクトバックログは **[GitHub Issue](https://github.com/rokusoudo-product/qa-count-hit-game/issues) を正**とする。
+`docs/backlog.md` は GitHub Issue と役割が重複し二重管理になっていたため、2026-08-06 に廃止して
+`archive/backlog_aws.md` へ凍結退避した（Issue #19）。ラベル運用は `ISSUE_WORKFLOW.md` に従う。
 
 ### 質問マスタ（36問）の正本管理（Issue #16）
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ hitokazu-game/
 │   ├── firestore.indexes.json
 │   └── web/
 │       └── index.html     # Webクライアント（ブラウザ参加用）
-└── docs/                  # 仕様・バックログ
+└── docs/                  # 仕様・要件（バックログは GitHub Issue が正）
 ```
 
 ---

--- a/archive/README.md
+++ b/archive/README.md
@@ -5,3 +5,7 @@
 - `terraform_aws/` : Terraform (Lambda / API Gateway / DynamoDB)
 - `lambda_aws/`    : Python Lambda ハンドラー
 - `layers_aws/`    : Lambda Layer (qrcode)
+- `backlog_aws.md` : AWS 時代のプロダクトバックログ（2026-08-06 に `docs/` から退避・凍結）
+
+**現行のバックログは [GitHub Issue](https://github.com/rokusoudo-product/qa-count-hit-game/issues) を正とします。**
+本ディレクトリの内容は移行前の遺構であり、実装の参照元にしないでください。

--- a/archive/backlog_aws.md
+++ b/archive/backlog_aws.md
@@ -1,7 +1,19 @@
-# プロダクトバックログ
+> # ⚠️ これは AWS 時代の記録です
+>
+> **現行のバックログは [GitHub Issue](https://github.com/rokusoudo-product/qa-count-hit-game/issues) を正とします。**
+> 本ファイルの内容を現在の計画・進捗として参照しないでください。
+>
+> - 2026-03-20 に AWS から Firebase へ移行したため、以下のタスク（DynamoDB / Terraform / API Gateway WebSocket / OkHttp WebSocket 前提）は**現行構成と対応しません**
+> - 「完了」と書かれていても実態と一致しない項目があります。たとえば `AND-011 接続エラー・再接続処理` は「完了」扱いですが**未実装**です（Issue #18）
+> - 2026-08-06 に `docs/backlog.md` から本ファイルへ退避しました（Issue #19）。GitHub Issue との二重管理を解消するためです
+
+---
+
+# プロダクトバックログ（AWS 時代・凍結）
 
 **作成日**: 2026-03-20
-**最終更新**: 2026-03-20
+**最終更新**: 2026-03-20（以降更新なし）
+**凍結日**: 2026-08-06
 
 優先度: 🔴 Must / 🟡 Should / 🟢 Could
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,76 +1,130 @@
 # システムアーキテクチャ概要
 
 **作成日**: 2026-03-20
-**最終更新**: 2026-03-20（AWS → Firebase移行）
-**バージョン**: 2.0
+**最終更新**: 2026-08-06（実装との乖離を解消。Issue #19）
+**バージョン**: 3.0
 
 ---
 
 ## 全体構成図
 
+```mermaid
+flowchart TB
+    subgraph Clients["クライアント"]
+        AND["Android アプリ<br/>Kotlin / Jetpack Compose"]
+        WEB["Web クライアント<br/>backend/web/index.html"]
+    end
+
+    subgraph Firebase["Firebase（GCP）"]
+        AUTH["Firebase Auth<br/>匿名認証"]
+        FS[("Cloud Firestore<br/>rooms/{roomId}/<br/>players・rounds・answers")]
+        HOSTING["Firebase Hosting<br/>招待ページ web/public/join/"]
+        FN["Cloud Functions Python 3.12<br/>us-central1"]
+    end
+
+    AND -->|匿名サインイン| AUTH
+    WEB -->|匿名サインイン| AUTH
+    AND <==>|直接読み書き＋リアルタイム購読| FS
+    WEB <==>|直接読み書き＋リアルタイム購読| FS
+    HOSTING -.->|ルームIDを渡す| AND
+    FN -.->|現状クライアントからは未使用| FS
+
+    style FN stroke-dasharray: 5 5
 ```
-[Android App]
-     │
-     ├── Callable Functions (HTTPS)
-     │       └── Firebase Cloud Functions (Python 3.12)
-     │                └── Firestore（読み書き）
-     │
-     └── Firestore Real-time Listener
-             └── Firestore → onSnapshot → UI更新
-                 （WebSocket不要・自動再接続）
-```
+
+### 最重要の前提
+
+**ゲームロジックはクライアント側にあり、クライアントは Firestore を直接読み書きする。**
+`backend/functions/main.py` に Cloud Functions が実装済みだが、**Android・Web のどちらからも呼び出していない**（図中の破線）。実装を読む・変更するときはこの前提を誤らないこと。
+
+この構成の帰結:
+
+- 採点・フェーズ遷移・タイムアウト確定はすべてクライアントが実行する
+- そのためスコア改ざんは Firestore ルールだけでは防ぎきれない（後述「セキュリティ」）
+- 将来ロジックをサーバー側へ移す場合は、既存の Cloud Functions が出発点になる
 
 ---
 
-## Firebase構成
+## Firebase 構成
 
-| コンポーネント | サービス | 用途 |
-|--------------|---------|------|
-| リアルタイムDB | Cloud Firestore | ゲーム状態・プレイヤー・回答管理 |
-| サーバーレス関数 | Cloud Functions (Python 3.12) | ゲームロジック・採点 |
-| リアルタイム通信 | Firestoreリスナー | WebSocket代替・自動再接続 |
-| Android SDK | Firebase SDK for Android | Firestore + Functions クライアント |
+| コンポーネント | サービス | 用途 | 現状 |
+|--------------|---------|------|------|
+| リアルタイムDB | Cloud Firestore | ゲーム状態・プレイヤー・回答管理 | ✅ 使用中 |
+| 認証 | Firebase Authentication（匿名） | プレイヤー識別（uid） | ✅ 使用中 |
+| ホスティング | Firebase Hosting | 招待ページ `web/public/join/` | ✅ 使用中 |
+| リアルタイム通信 | Firestore リスナー（`addSnapshotListener`） | WebSocket 代替 | ✅ 使用中 |
+| サーバーレス関数 | Cloud Functions (Python 3.12 / us-central1) | ゲームロジック・採点 | ⚠️ **実装済みだが未使用** |
 
 ---
 
 ## Firestore データ構造
 
-```
-rooms/{roomId}
-  ├── hostName: string
-  ├── status: "WAITING" | "ANSWERING" | "PREDICTING" | "RESULT" | "FINISHED"
-  ├── currentRound: number
-  ├── totalRounds: number
-  ├── currentQuestion: { questionId, text, options, answerSeconds, predictSeconds }
-  ├── answerCounts: { "選択肢A": 3, "選択肢B": 2 }
-  ├── roundScores: [PlayerScore]
-  ├── finalScores: [PlayerScore]
-  └── createdAt: timestamp
+実装（`android/.../data/model/Models.kt` と `data/firebase/FirebaseRepository.kt`）に一致させること。
 
-rooms/{roomId}/players/{playerId}
-  ├── nickname: string
-  ├── isHost: boolean
-  └── joinedAt: timestamp
+### `rooms/{roomId}`
 
-rooms/{roomId}/rounds/{round}/answers/{playerId}
-  ├── answer: string
-  ├── prediction: number
-  ├── targetOption: string
-  ├── roundScore: number
-  └── answeredAt: timestamp
-```
+| フィールド | 型 | 書き込み箇所 | 説明 |
+|---|---|---|---|
+| `hostName` | string | createRoom | ホストのニックネーム |
+| `hostUid` | string | createRoom | ホストの Firebase uid。ルール判定に使う |
+| `status` | string | 各所 | `WAITING` / `ANSWERING` / `PREDICTING` / `RESULT` / `FINISHED` |
+| `currentRound` | number | createRoom / startGame / 次ラウンド | 現在のラウンド番号 |
+| `totalRounds` | number | createRoom / startGame | 1ゲームの出題数（既定5） |
+| `category` | string | createRoom | `QuestionCategory` の名前（`ALL` / `FRIEND` / `PARTY` / `DEEP`） |
+| `currentQuestion` | map | createRoom / startGame / 次ラウンド | `{ questionId, text, options, answerSeconds, predictSeconds, tags }` |
+| `questionQueue` | array\<map\> | startGame | ゲーム開始時に抽選した出題リスト |
+| `answerCounts` | map\<string,number\> | 予測フェーズ移行時 | 選択肢ごとの回答人数 |
+| `roundScores` | array\<PlayerScore\> | ラウンド確定時 | 当該ラウンドのスコア |
+| `finalScores` | array\<PlayerScore\> | ゲーム終了時 | 最終スコア |
+| `cumulativeTotals` | map | ラウンド確定時 / 終了時 | プレイヤーごとの累計得点 |
+| `nextRound` | number | ラウンド確定時 | 次に進むラウンド番号 |
+| `phaseStartedAt` | timestamp | フェーズ遷移時 | **現フェーズの開始サーバー時刻。タイムアウト判定の基準**（Issue #14） |
+| `createdAt` | timestamp | createRoom | ルーム作成時刻 |
+| `startedAt` | timestamp | startGame | ゲーム開始時刻 |
+| `finishedAt` | timestamp | ゲーム終了時 | ゲーム終了時刻 |
+
+`PlayerScore` の構造: `{ playerId, nickname, targetOption, predictedCount, actualCount, roundScore, totalScore }`
+
+### `rooms/{roomId}/players/{uid}`
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `nickname` | string | 表示名 |
+| `isHost` | boolean | ホストかどうか |
+| `joinedAt` | timestamp | 入室時刻 |
+
+### `rooms/{roomId}/rounds/{round}/answers/{uid}`
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `answer` | string | 選択した選択肢 |
+| `answeredAt` | timestamp | 回答時刻 |
+| `prediction` | number | 予測人数 |
+| `targetOption` | string | 予測対象の選択肢 |
+| `predictedAt` | timestamp | 予測時刻 |
+| `roundScore` | number | 採点結果（確定時に書き込まれる） |
+
+### ルームID
+
+`FirebaseRepository.generateRoomId()` が生成する **8桁のランダム文字列**。
+文字集合は `ABCDEFGHJKLMNPQRSTUVWXYZ23456789`（32文字）で、誤読しやすい `I` / `O` / `0` / `1` を除いてある。
+**UUID ではない**（口頭・手入力で共有するため短くしている）。
 
 ---
 
-## Cloud Functions 一覧
+## Cloud Functions 一覧（現状クライアントからは未使用）
 
-| 関数名 | トリガー | 説明 |
-|--------|---------|------|
-| `create_room` | Callable | ルームID生成・Firestore保存 |
-| `join_room` | Callable | プレイヤー参加・バリデーション |
-| `start_game` | Callable | ゲーム開始・最初の質問セット |
-| `submit_answer` | Callable | 回答保存・全員完了で予測フェーズ移行 |
-| `submit_prediction` | Callable | 予測保存・採点・次ラウンド/終了 |
+`backend/functions/main.py`。HTTPS 関数として `us-central1` にデプロイされる。
+
+| 関数名 | 説明 |
+|--------|------|
+| `create_room` | ルームID生成・Firestore 保存 |
+| `join_room` | プレイヤー参加・バリデーション |
+| `start_game` | ゲーム開始・最初の質問セット |
+| `submit_answer` | 回答保存・全員完了で予測フェーズ移行 |
+| `submit_prediction` | 予測保存・採点・次ラウンド/終了 |
+
+> ⚠️ **これらは現役の API ではない。** クライアントは Firestore を直接読み書きしており、この5関数を呼んでいない。ロジックをサーバー側へ移す判断をした時点で、改めて現行のクライアント実装と突き合わせる必要がある。
 
 ---
 
@@ -79,17 +133,20 @@ rooms/{roomId}/rounds/{round}/answers/{playerId}
 ```
 WAITING（待合室）
   ↓ ホストがゲーム開始
-ANSWERING（回答フェーズ：30秒）
-  ↓ 全員回答完了
-PREDICTING（予測フェーズ：20秒）
-  ↓ 全員予測完了
+ANSWERING（回答フェーズ：既定 answerSeconds = 30秒）
+  ↓ 全員回答完了、または answerSeconds + 猶予3秒の経過（ホスト端末が確定）
+PREDICTING（予測フェーズ：既定 predictSeconds = 20秒）
+  ↓ 全員予測完了、または predictSeconds + 猶予3秒の経過（ホスト端末が確定）
 RESULT（結果表示：10秒）
   ↓ 次のラウンドへ or ゲーム終了
 FINISHED（最終結果）
 ```
 
-**状態変更はFirestoreドキュメントの更新で行い、
-AndroidはonSnapshotリスナーで自動検知・UI更新する。**
+- 状態変更は Firestore ドキュメントの更新で行い、各クライアントは `addSnapshotListener` で自動検知して UI を更新する
+- **タイムアウトはホスト端末が主導して確定させる**（Issue #14）。基準時刻は端末のローカル時計ではなく `phaseStartedAt`（サーバー時刻）から算出するため、途中参加・画面復帰した端末でもズレない
+- 未提出者は当該ラウンドのスコア集計から除外される
+
+> ⚠️ ホスト自身が離脱するとタイムアウト確定を実行する主体がいなくなる。この扱いは Issue #15 で対応する（Firestore ハートビートで検知し、ルームを終了する方針で確定済み）。
 
 ---
 
@@ -100,12 +157,70 @@ AndroidはonSnapshotリスナーで自動検知・UI更新する。**
 スコア = max(0, 100 - 差分 × 20)
 ```
 
+ぴったり当てると100点、1人ずれるごとに20点減点。実装は `FirebaseRepository` と `backend/test_logic.py` にある。
+
 ---
 
-## AWSからの移行メモ
+## 質問マスタ（Issue #16）
 
-旧AWS実装は `archive/` ディレクトリに保存済み。
-- WebSocket API Gateway → Firestoreリアルタイムリスナー
-- Lambda → Cloud Functions
-- DynamoDB → Cloud Firestore
-- Terraform → Firebase CLI
+質問マスタ（36問）は **`shared/questions.json` が単一の正本**で、次の3実装はそこから生成される。**生成物を直接編集しないこと。**
+
+- `android/app/src/main/java/com/rokusoudo/hitokazu/data/questions/Questions.kt`
+- `backend/functions/questions.py`
+- `backend/web/index.html`（`// GENERATED:QUESTIONS:START` 〜 `:END` の区間）
+
+```bash
+python3 scripts/generate_questions.py         # 3実装へ反映
+python3 scripts/generate_questions.py --check # 同期検証のみ（CI で実行）
+```
+
+各質問は `tags`（`friend` / `party` / `deep`）を持ち、ルームの `category` で絞り込まれる。
+
+> ⚠️ カテゴリによる絞り込みは**現状 Android 側にしか実装がない**。Web クライアントは全問から抽選する。是正は Issue #12。
+
+---
+
+## セキュリティ（Firestore ルール）
+
+`backend/firestore.rules` は**ルーム単位の権限**で保護している。
+
+| パス | read | create | update | delete |
+|---|---|---|---|---|
+| `rooms/{roomId}` | 認証済み | `hostUid == 自分` | 参加者 | ホスト |
+| `players/{uid}` | 参加者 | 自分のみ | 自分のみ | 自分 or ホスト |
+| `rounds/{n}/answers/{uid}` | 参加者 | 参加者かつ自分 | 参加者※ | ホスト |
+
+ルーム本体の read だけ認証済みに開放しているのは、`joinRoom()` が入室前に存在確認・満員判定でルームを読む必要があるため。
+
+> ⚠️ **※ スコア改ざんは防ぎきれていない。** 採点はクライアントが実行し、実行者は「最後に予測を送信したプレイヤー」でホストとは限らない。この処理が他プレイヤーの `roundScore` を書くため、`answers` の update を自分のドキュメントに限定できない。無関係な第三者による覗き見・妨害は塞げているが、**同一ルームの参加者による改ざんはルール層では防げない**。根本的に塞ぐにはゲームロジックを Cloud Functions 側へ移す必要がある。
+
+ルールのテストは `backend/rules-tests/`（権限マトリクス24件＋実ゲームフロー8件）。
+
+---
+
+## テストと CI
+
+| ファイル | 内容 | CI |
+|---|---|---|
+| `backend/test_logic.py` | 採点ロジック単体（Firestore 非依存） | ✅ |
+| `backend/test_questions_sync.py` | 質問マスタの正本と3実装の一致検証 | ✅ |
+| `backend/rules-tests/` | Firestore ルール（Emulator 上で32件） | ✅ |
+| `backend/test_game_flow.py` | Emulator 統合テスト | — |
+| `backend/test_functions.py` | ⚠️ **本番 Firestore に直接書き込む**。CI に含めない | ❌ |
+
+`.github/workflows/ci.yml` が `main` 宛の PR と `main` への push で自動実行する（Issue #13）。lint（Python: flake8）も同ワークフローに含まれる。
+
+---
+
+## AWS からの移行メモ
+
+旧 AWS 実装は `archive/` に保存済み。現行構成では使用しない。
+
+| 旧（AWS） | 現行（Firebase） |
+|---|---|
+| WebSocket API Gateway | Firestore リアルタイムリスナー |
+| Lambda | Cloud Functions（ただし現状未使用） |
+| DynamoDB | Cloud Firestore |
+| Terraform | Firebase CLI（`backend/firebase.json`） |
+
+移行前のバックログは `archive/backlog_aws.md` に退避してある。**現行のバックログは GitHub Issue を正とする。**

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -2,7 +2,8 @@
 
 **プロジェクト名**: 人数当てゲーム
 **作成日**: 2026-03-20
-**バージョン**: 1.0
+**最終更新**: 2026-08-06（AWS 前提の記述を現行 Firebase 構成に是正。Issue #19）
+**バージョン**: 2.0
 **作成者**: POエージェント（株式会社六創堂）
 
 ---
@@ -57,8 +58,9 @@
 - 最終的なランキングを表示
 
 ### 3.5 リアルタイム通信
-- WebSocket（AWS API Gateway）を使ったリアルタイム同期
+- Cloud Firestore のリアルタイムリスナー（`addSnapshotListener`）による同期。WebSocket もポーリングも使わない
 - 参加者の入退室・回答状況をリアルタイム反映
+- クライアント（Android / Web）は Firestore を**直接読み書き**する。Cloud Functions は実装済みだが経由していない（`docs/architecture.md` 参照）
 
 ---
 
@@ -66,20 +68,24 @@
 
 | 項目 | 要件 |
 |------|------|
-| プラットフォーム | Android（minSdk 26 / API Level 26以上） |
+| プラットフォーム | Android（minSdk 26 / API Level 26以上）＋ Web ブラウザ（参加・ホストとも可） |
 | 同時接続数 | 1ルームあたり最大20人 |
 | レスポンス | 回答反映は3秒以内 |
-| 可用性 | AWS Lambda + DynamoDB（サーバーレス構成） |
-| セキュリティ | ルームIDはUUID、外部から推測不可 |
-| コスト | AWS無料枠での運用を優先 |
+| 可用性 | Firebase（Cloud Firestore + Authentication + Hosting）のマネージドサービスに依拠する |
+| セキュリティ | ルームIDは8桁のランダム文字列（`ABCDEFGHJKLMNPQRSTUVWXYZ23456789` の32文字集合。誤読しやすい `I`/`O`/`0`/`1` を除外）。Firestore セキュリティルールでルーム単位に権限を絞る |
+| コスト | Firebase（GCP）無料枠での運用を優先 |
+
+> ⚠️ 採点処理をクライアントが実行する構成のため、**同一ルームの参加者によるスコア改ざんはセキュリティルールでは防げない**。無関係な第三者による覗き見・妨害は塞いである。詳細と対処方針は `docs/architecture.md`「セキュリティ」を参照。
 
 ---
 
-## 5. スコープ外（v1.0）
+## 5. スコープ外
+
+2026-08-06 時点でも据え置き（代表判断）。
 
 - iOSアプリ対応
 - アカウント登録・ログイン機能
-- カスタム質問作成（初期はプリセット質問のみ）
+- カスタム質問作成（プリセット質問のみ。質問マスタは `shared/questions.json` の36問）
 - 音声・動画チャット
 - 広告掲載
 
@@ -88,5 +94,13 @@
 ## 6. 制約事項
 
 - Google Playポリシー準拠
-- 個人情報は収集しない（ニックネームのみ）
-- AWS東京リージョン使用
+- 個人情報は収集しない（ニックネームと Firebase 匿名認証の uid のみ）
+- Cloud Functions のリージョンは `us-central1`（`backend/functions/main.py`）
+
+---
+
+## 7. バックログ管理
+
+現行のバックログは **GitHub Issue を正**とする（https://github.com/rokusoudo-product/qa-count-hit-game/issues）。
+
+かつて `docs/backlog.md` で管理していたが、GitHub Issue と役割が重複し二重管理になっていたため 2026-08-06 に廃止した（Issue #19）。AWS 時代の記録は `archive/backlog_aws.md` に退避してある。


### PR DESCRIPTION
## 背景

`docs/` が 2026-03-20 の AWS 時代のまま止まっており、現行の Firebase 実装と食い違っていました。`CLAUDE.md` が「実装前に `docs/architecture.md` を読むこと」と指示しているため、**この乖離は毎朝の自動実装ルーティンが起動するサブエージェントを毎回誤らせていました**。#17 / #18 / #19 の3提案のうち本件を最優先としたのはこのためです。

## 変更内容

### `docs/architecture.md`（v2.0 → v3.0）

| 項目 | 修正前 | 修正後 |
|---|---|---|
| 全体構成図 | Android → Callable Functions → Firestore | **クライアント → Firestore 直接読み書き**。Cloud Functions は実装済みだが未使用である旨を「最重要の前提」として明記 |
| Firestore データ構造 | room に9項目のみ | **実装と突き合わせて全項目**。欠落していた `hostUid` / `category` / `questionQueue` / `cumulativeTotals` / `nextRound` / `phaseStartedAt` / `startedAt` / `finishedAt` を追加し、書き込み箇所も併記 |
| ルームID | 記載なし | 8桁ランダム（`ABCDEFGHJKLMNPQRSTUVWXYZ23456789`。誤読しやすい `I`/`O`/`0`/`1` を除外）。**UUID ではない**ことを明記 |
| Cloud Functions 一覧 | 現役の API のように5関数を列挙 | 「**現状クライアントからは未使用**」を見出しと注記の両方に明示 |
| フェーズ遷移 | 全員提出のみ | ホスト端末主導のタイムアウト（#14）と `phaseStartedAt` 基準を追記。ホスト離脱時の課題（#15）にも言及 |
| 質問マスタ | 記載なし | `shared/questions.json` を正本とする生成方式（#16）を追記。Web にカテゴリ絞り込みが無い件（#12）も明記 |
| セキュリティ | 記載なし | `firestore.rules` の権限マトリクスと、**クライアント採点ゆえにスコア改ざんを防ぎきれない**制約を追記 |
| テスト / CI | 記載なし | 各テストの位置づけと CI（#13）の対象を表で追記 |

データ構造は `android/.../data/model/Models.kt` と `data/firebase/FirebaseRepository.kt` の書き込み箇所を実際に読んで突き合わせています。

### `docs/requirements.md`（v1.0 → v2.0）

- 3.5 リアルタイム通信: WebSocket（AWS API Gateway）→ **Firestore リスナー**
- 非機能要件: 可用性「AWS Lambda + DynamoDB」→ Firebase、コスト「AWS 無料枠」→ Firebase（GCP）無料枠
- 非機能要件: セキュリティ「ルームIDは**UUID**」→ 実装どおり8桁ランダム。あわせてスコア改ざんリスクを注記
- 制約事項: 「AWS 東京リージョン使用」→ Cloud Functions は `us-central1`
- プラットフォームに Web ブラウザを追記（README の「プレイ方法」どおりホストにもなれるため）
- スコープ外は**据え置き**（代表判断）

3.2 / 3.3 のタイムアウト記述は #14 のマージ時に更新済みだったため、本 PR では触っていません。

### バックログの一本化

`docs/backlog.md` は GitHub Issue と役割が重複していたため**廃止**しました（代表判断）。

- `git mv` で `archive/backlog_aws.md` へ退避し、**ファイル履歴を保持**しています
- 冒頭に「これは AWS 時代の記録。現行のバックログは GitHub Issue が正」の警告ブロックを付与
- 「完了」扱いだが実態は未実装である `AND-011 接続エラー・再接続処理`（Issue #18）にも具体的に言及
- `CLAUDE.md` / `README.md` / `archive/README.md` の参照とディレクトリ図を更新
- `CLAUDE.md` の PO エージェントの役割を「バックログ管理」→「GitHub Issue の起票と優先度づけ」に変更

## 受け入れ基準の検証

`grep` で機械的に確認しました。

| 基準 | 結果 |
|---|---|
| `docs/` に DynamoDB / Lambda / API Gateway / Terraform / WebSocket が現行構成の説明として 0 件 | ✅ 残ったヒットは「WebSocket もポーリングも使わない」等の**否定表現**と、「AWS からの移行メモ」の**対比表**のみ |
| 構成図が Firestore 直接読み書きになっており Functions 未使用が明記 | ✅ |
| データ構造が `Models.kt` と一致 | ✅ 全項目を突き合わせ済み |
| ルームID仕様が実装（8桁ランダム）と一致 | ✅ |
| `docs/backlog.md` が `archive/` へ移されている | ✅ `git mv` で履歴保持 |
| 移動先に「現行は GitHub Issue が正」と明記 | ✅ |
| `docs/backlog.md` への参照が残っていない | ⚠️ **下記のとおり2件を意図的に残しています** |
| 最終更新日の更新 | ✅ |

**意図的に残した2件について**: `CLAUDE.md` と `docs/requirements.md` に「かつて `docs/backlog.md` で管理していたが廃止した」という**経緯の説明**が残っています。これは読者を存在しないファイルへ誘導する参照ではなく、なぜ無いのかを説明するものなので残すべきと判断しました。削除したほうがよければ対応します。

## テスト

ドキュメントのみの変更ですが、ブランチの健全性を確認しました。

- `backend/test_logic.py` ✅ 全件合格
- `backend/test_questions_sync.py` ✅ 36問が3実装で同期
- `scripts/generate_questions.py --check` ✅ 同期済み

## 別途ご判断いただきたい点（本 PR のスコープ外）

作業中に **`README.md` にも実装との乖離**を見つけました。本 Issue の受け入れ基準は `docs/` 配下が対象なので手を付けていません。

1. 「## 質問リスト（5問）」として5問だけ列挙しているが、実際の質問マスタは **36問**（`shared/questions.json`）。5は1ゲームの出題数
2. 「Firestoreデータ構造」の JSON 例に `hostUid` / `category` / `questionQueue` / `cumulativeTotals` / `phaseStartedAt` などが欠けている
3. 「ゲームの状態遷移」に全員提出しか書かれておらず、#14 で入ったタイムアウトによる遷移が反映されていない

別 Issue を起票しましょうか。

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)
