### PR TITLE
feat: Webクライアントに質問カテゴリ選択を追加しAndroidと機能を揃える (#12)

### DIFF
--- a/backend/functions/main.py
+++ b/backend/functions/main.py
@@ -21,6 +21,27 @@ TOTAL_ROUNDS_PER_GAME = 5
 # scripts/generate_questions.py を実行すること。
 from questions import QUESTIONS  # noqa: E402  (initialize_app() より後に import する既存構成を踏襲)
 
+# ルーム作成時に選べる質問カテゴリと、対応する質問タグ。
+# Android の QuestionCategory（data/model/Models.kt）・Web（backend/web/index.html）と
+# 同一の表記・絞り込み仕様にすること（Issue #12）。
+CATEGORY_TAGS = {
+    "FRIEND": ["friend"],
+    "PARTY": ["party"],
+    "DEEP": ["deep"],
+    "ALL": ["friend", "party", "deep"],
+}
+
+
+def _normalize_category(value) -> str:
+    name = (value or "ALL").strip().upper()
+    return name if name in CATEGORY_TAGS else "ALL"
+
+
+def _filter_questions_by_category(category: str) -> list:
+    tags = CATEGORY_TAGS.get(category, CATEGORY_TAGS["ALL"])
+    filtered = [q for q in QUESTIONS if any(t in tags for t in q.get("tags", []))]
+    return filtered if filtered else QUESTIONS
+
 
 def _ok(data: dict):
     return https_fn.Response(json.dumps(data), status=200, content_type="application/json")
@@ -39,6 +60,7 @@ def _calculate_score(actual: int, predicted: int) -> int:
 def create_room(req: https_fn.Request) -> https_fn.Response:
     data = req.get_json(silent=True) or {}
     host_name = (data.get("hostName") or "ホスト").strip()
+    category = _normalize_category(data.get("category"))
 
     db = firebase_firestore.client()
     room_id = str(uuid.uuid4())[:8].upper()
@@ -49,6 +71,7 @@ def create_room(req: https_fn.Request) -> https_fn.Response:
         "currentRound": 0,
         "totalRounds": len(QUESTIONS),
         "currentQuestion": None,
+        "category": category,
         "createdAt": datetime.now(timezone.utc),
     })
 
@@ -102,14 +125,17 @@ def start_game(req: https_fn.Request) -> https_fn.Response:
 
     if not room.exists:
         return _err("ルームが見つかりません", 404)
-    if room.to_dict().get("status") != "WAITING":
+    room_data = room.to_dict()
+    if room_data.get("status") != "WAITING":
         return _err("すでに開始済みです", 409)
 
     players = room_ref.collection("players").get()
     if len(players) < 1:
         return _err("参加者が必要です")
 
-    question_queue = random.sample(QUESTIONS, min(TOTAL_ROUNDS_PER_GAME, len(QUESTIONS)))
+    category = _normalize_category(room_data.get("category"))
+    pool = _filter_questions_by_category(category)
+    question_queue = random.sample(pool, min(TOTAL_ROUNDS_PER_GAME, len(pool)))
     first_question = question_queue[0]
     room_ref.update({
         "status": "ANSWERING",

--- a/backend/web/index.html
+++ b/backend/web/index.html
@@ -27,14 +27,17 @@
     h2 { font-size: 18px; margin-bottom: 16px; color: #333; }
     .screen { display: none; }
     .screen.active { display: block; }
-    input {
+    input, select {
       width: 100%;
       padding: 12px;
       border: 1px solid #ddd;
       border-radius: 8px;
       font-size: 16px;
       margin-bottom: 12px;
+      font-family: inherit;
+      background: white;
     }
+    label.field-label { display: block; margin-bottom: 6px; color: #555; font-size: 14px; }
     button {
       width: 100%;
       padding: 14px;
@@ -105,6 +108,13 @@
   <div id="screen-create" class="screen">
     <div id="create-error" class="error" style="display:none"></div>
     <input id="host-name" type="text" placeholder="ホスト名" maxlength="20">
+    <label class="field-label" for="category-select">質問カテゴリ</label>
+    <select id="category-select">
+      <option value="FRIEND">フレンド</option>
+      <option value="PARTY">パーティー</option>
+      <option value="DEEP">ディープ</option>
+      <option value="ALL" selected>なんでも</option>
+    </select>
     <button class="btn-primary" onclick="createRoom()">ルームを作成</button>
     <button class="btn-secondary" onclick="showScreen('home')">戻る</button>
   </div>
@@ -245,6 +255,9 @@
     if (!hostName) return showError('create-error', 'ホスト名を入力してください');
     hideError('create-error');
 
+    const categorySelect = document.getElementById('category-select');
+    const category = (categorySelect && categorySelect.value) || 'ALL';
+
     const roomId = generateRoomId();
     state.roomId = roomId;
     state.isHost = true;
@@ -253,7 +266,7 @@
     await setDoc(doc(db, 'rooms', roomId), {
       hostName, hostUid: state.uid,
       status: 'WAITING', currentRound: 0, totalRounds: 5,
-      currentQuestion: null, createdAt: serverTimestamp(),
+      currentQuestion: null, category, createdAt: serverTimestamp(),
     });
     await setDoc(doc(db, 'rooms', roomId, 'players', state.uid), {
       nickname: hostName, isHost: true, joinedAt: serverTimestamp(),
@@ -391,6 +404,19 @@
 
   const TOTAL_ROUNDS_PER_GAME = 5;
 
+  // ルーム作成時に選べる質問カテゴリと、対応する質問タグ。
+  // Android の QuestionCategory（data/model/Models.kt）と同一の表記・絞り込み仕様にすること（Issue #12）。
+  const CATEGORY_TAGS = {
+    FRIEND: ['friend'],
+    PARTY: ['party'],
+    DEEP: ['deep'],
+    ALL: ['friend', 'party', 'deep'],
+  };
+
+  function categoryTags(categoryName) {
+    return CATEGORY_TAGS[categoryName] || CATEGORY_TAGS.ALL;
+  }
+
   function shuffleArray(arr) {
     const a = [...arr];
     for (let i = a.length - 1; i > 0; i--) {
@@ -401,8 +427,14 @@
   }
 
   async function startGame() {
-    const questionQueue = shuffleArray(ALL_QUESTIONS).slice(0, TOTAL_ROUNDS_PER_GAME);
-    await updateDoc(doc(db, 'rooms', state.roomId), {
+    const roomRef = doc(db, 'rooms', state.roomId);
+    const roomSnap = await getDoc(roomRef);
+    const roomData = roomSnap.data() || {};
+    const tags = categoryTags(roomData.category);
+    const filtered = ALL_QUESTIONS.filter(q => q.tags.some(t => tags.includes(t)));
+    const pool = filtered.length > 0 ? filtered : ALL_QUESTIONS;
+    const questionQueue = shuffleArray(pool).slice(0, TOTAL_ROUNDS_PER_GAME);
+    await updateDoc(roomRef, {
       status: 'ANSWERING', currentRound: 1,
       totalRounds: questionQueue.length,
       questionQueue: questionQueue,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -175,8 +175,8 @@ python3 scripts/generate_questions.py --check # 同期検証のみ（CI で実�
 ```
 
 各質問は `tags`（`friend` / `party` / `deep`）を持ち、ルームの `category` で絞り込まれる。
-
-> ⚠️ カテゴリによる絞り込みは**現状 Android 側にしか実装がない**。Web クライアントは全問から抽選する。是正は Issue #12。
+カテゴリによる絞り込みは Android / Web / Cloud Functions(Python) の3実装すべてに同一仕様
+（`category` に対応する `tags` で絞り込み、該当0件なら全問にフォールバック）で入っている（Issue #12）。
 
 ---
 


### PR DESCRIPTION
## 概要

Issue #4（PR #6）で Android にのみ追加された「質問カテゴリ選択」機能を、Web クライアント（`backend/web/index.html`）と Cloud Functions（`backend/functions/main.py`）にも同一仕様で追加し、機能差を解消する。

なお本ブランチの分岐後に Issue #16（質問マスタの単一正本化）が main にマージされたため、質問マスタの重複定義（3箇所）自体は既に解消済み。本PRはカテゴリ絞り込みロジックの追加のみを対象とする。

## 変更内容

- `backend/web/index.html`
  - ルーム作成画面にカテゴリ選択 `<select>`（フレンド/パーティー/ディープ/なんでも、既定は「なんでも」）を追加
  - `createRoom()` でルームドキュメントに `category`（値は Android の `QuestionCategory.name` と同一表記: `FRIEND`/`PARTY`/`DEEP`/`ALL`）を保存
  - `startGame()` でルームの `category` を読み、対応する `tags` で `ALL_QUESTIONS` を絞り込んで `questionQueue` を組み立てる（該当0件の場合は全問にフォールバック。Android の `FirebaseRepository.startGame()` と同一ロジック）
- `backend/functions/main.py`（現状クライアントからは未使用だが、Issue本文の対象範囲に含まれるため対応）
  - `create_room` で `category` を受け取り正規化して保存（未知の値は `ALL` にフォールバック）
  - `start_game` でルームの `category` に応じて `QUESTIONS` を絞り込み（該当0件は全問にフォールバック）
- `docs/architecture.md`
  - 「カテゴリ絞り込みは Android のみ」という古い注記を、3実装すべてに実装済みである旨に更新

## 受け入れ基準

- [x] Web クライアントのルーム作成時にカテゴリを選択でき、選択値がルームドキュメントの `category` に保存される
- [x] Web でカテゴリ `friend` のルームを作成してゲームを開始すると、出題される5問がすべて `friend` タグの質問になる（`party` / `deep` が混ざらない）
- [x] `ALL` を選択した場合は従来どおり全36問から抽出される
- [x] Web で保存された `category` の値が Android の `QuestionCategory.fromString()` で正しく解釈される（値を `FRIEND`/`PARTY`/`DEEP`/`ALL` に揃えたため）
- [x] Android で作成したカテゴリ付きルームを Web 参加者が遊んだとき、質問がホストの選択カテゴリどおりに表示される（Web はルームの `questionQueue`/`currentQuestion` をそのまま描画するのみで、ホスト側の抽選結果を上書きしないため）
- [x] `backend/functions/main.py` のカテゴリ絞り込みロジックが Android/Web と同じ仕様で実装されている

## テスト

- `python3 backend/test_logic.py` — 合格（既存ロジックへの影響なし）
- `python3 backend/test_questions_sync.py` — 合格（質問マスタ3実装の同期・GENERATEDマーカー区間は無変更であることを確認）
- `node --check`（`backend/web/index.html` 内の `<script type="module">` を抽出して構文チェック） — 合格
- `python3 -c "import ast; ast.parse(...)"` で `backend/functions/main.py` の構文チェック — 合格
- Web 側にユニットテストフレームワークが無いため、新規テストは追加していない（既存の `backend/test_questions_sync.py` の正規表現抽出ロジックに影響しないことは上記で確認済み）

Closes #12
