### PR TITLE
docs: README の質問数・Firestore データ構造・状態遷移を実装に合わせる

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,9 @@ npm --prefix rules-tests run test:emulator
 `main` 宛の Pull Request と `main` への push で [`.github/workflows/ci.yml`](.github/workflows/ci.yml) が自動実行されます。
 
 - `backend/test_logic.py`（採点ロジック単体テスト）
+- `backend/test_questions_sync.py`（質問マスタの正本と3実装の同期検証）
 - `backend/rules-tests/`（Firestoreルールテスト・権限マトリクス24件＋実ゲームフロー8件、Firebase Emulator上で実行）
-- lint（Python: flake8）
+- lint（Python: flake8 / JS: rules-tests に設定があれば実行）
 
 テストが1件でも失敗するとCIが失敗（レッド）になり、PR上にステータスとして表示されます。
 `test_functions.py` は本番Firestoreに直接書き込むスクリプトのため、CIには含めていません（手動実行のみ）。
@@ -177,21 +178,36 @@ Android / ブラウザ
 ```json
 {
   "hostName": "string",
+  "hostUid": "string",
   "status": "WAITING | ANSWERING | PREDICTING | RESULT | FINISHED",
   "currentRound": 1,
   "totalRounds": 5,
+  "category": "ALL | FRIEND | PARTY | DEEP",
   "currentQuestion": {
-    "questionId": "q001",
+    "questionId": "f001",
     "text": "犬を飼ったことがある？",
     "options": ["はい", "いいえ"],
     "answerSeconds": 30,
-    "predictSeconds": 20
+    "predictSeconds": 20,
+    "tags": ["friend"]
   },
+  "questionQueue": [...],
   "answerCounts": { "はい": 3, "いいえ": 2 },
   "roundScores": [...],
-  "finalScores": [...]
+  "finalScores": [...],
+  "cumulativeTotals": { "<playerId>": 240 },
+  "nextRound": 2,
+  "phaseStartedAt": "timestamp",
+  "createdAt": "timestamp",
+  "startedAt": "timestamp",
+  "finishedAt": "timestamp"
 }
 ```
+
+- `hostUid` は Firestore ルールのホスト判定に使います
+- `phaseStartedAt` は**タイムアウト判定の基準となるサーバー時刻**です（下記「ゲームの状態遷移」）
+- 各フィールドの型・書き込み箇所を含む網羅的な一覧は [docs/architecture.md](docs/architecture.md#firestore-データ構造) にあります。
+  実装を変更するときはそちらを正としてください
 
 ---
 
@@ -206,17 +222,39 @@ WAITING → ANSWERING → PREDICTING → RESULT → ANSWERING → ...→ FINISHE
 - ホストが10秒後に自動で次ラウンド（`ANSWERING`）へ進行
 - 最終ラウンド終了後は `FINISHED` へ遷移
 
+### タイムアウトによる遷移
+
+**全員が提出しなくてもフェーズは進みます。** 1人が離席・通信断を起こしただけでゲームが止まらないようにするためです。
+
+- `ANSWERING` は `answerSeconds`（既定30秒）＋猶予3秒、`PREDICTING` は `predictSeconds`（既定20秒）＋猶予3秒が経過すると、**ホスト端末が提出済みの分だけで確定**させて次のフェーズへ進めます
+- 判定の基準時刻は端末のローカル時計ではなく、ルームドキュメントの `phaseStartedAt`（サーバー時刻）から算出します。途中参加・画面復帰した端末でも基準がズレません
+- 未提出者は当該ラウンドのスコア集計から除外されます
+
 ---
 
-## 質問リスト（5問）
+## 質問マスタ（36問）
 
-| No. | 質問 |
-|-----|------|
-| 1 | 犬を飼ったことがある？ |
-| 2 | 朝ごはんを毎日食べる？ |
-| 3 | 運転免許を持っている？ |
-| 4 | 海外に行ったことがある？ |
-| 5 | コーヒーを毎日飲む？ |
+質問は全部で **36問**あり、**1ゲームではそこから5問**が抽選されて出題されます（`TOTAL_ROUNDS_PER_GAME = 5`）。
+
+質問の内容は [`shared/questions.json`](shared/questions.json) が**単一の正本**です。README には転記しません（二重管理を避けるため）。
+
+各質問はカテゴリタグを持ち、ルーム作成時に選んだカテゴリで絞り込まれます。
+
+| カテゴリ | タグ | 用途 |
+|---|---|---|
+| なんでも | `friend` + `party` + `deep` | 既定。全36問から抽選 |
+| フレンド | `friend` | 気軽な話題 |
+| パーティー | `party` | 場を盛り上げる話題 |
+| ディープ | `deep` | 関係性が近い相手・成人向けの話題 |
+
+質問を追加・変更するときは `shared/questions.json` を編集し、生成スクリプトで Kotlin / JavaScript / Python の3実装へ反映します。
+
+```bash
+python3 scripts/generate_questions.py         # 3実装へ反映
+python3 scripts/generate_questions.py --check # 同期しているか検証（CI で実行）
+```
+
+生成先（`data/questions/Questions.kt` / `backend/functions/questions.py` / `backend/web/index.html` の生成マーカー区間）は**直接編集しないでください**。詳細は [docs/architecture.md](docs/architecture.md) を参照。
 
 ---
 


### PR DESCRIPTION
## 背景

#19（`docs/` の是正）の作業中に判明した **`README.md` の乖離3点**を是正します。README は最も読まれるファイルで、`docs/architecture.md` と並んでエージェント・人間の双方が最初に参照するため、放置すると #19 で解消した誤解が README 経由で再生産されます。

## 変更内容

### 1. 質問数「5問」→ 質問マスタ36問

「## 質問リスト（5問）」として5問だけを列挙していましたが、質問マスタは **36問**（`shared/questions.json`）です。**5は1ゲームの出題数**（`FirebaseRepository.kt` の `TOTAL_ROUNDS_PER_GAME = 5`）で、見出しがこの2つを取り違えていました。

- 見出しを「## 質問マスタ（36問）」に変更し、**36問と1ゲーム5問を明示的に区別**
- **質問文の列挙をやめ、`shared/questions.json` を正として参照する形に変更**しました。README に転記すると #16 で単一正本化した意味が失われ、質問を増やすたびに README が腐るためです
- カテゴリ（`friend` / `party` / `deep`）による絞り込みを表で追記
- 生成コマンド（`scripts/generate_questions.py`）と「生成先を直接編集しない」注意を追記

### 2. Firestore データ構造にフィールドを追加

JSON 例に以下が欠けていたので追加しました。

`hostUid` / `category` / `questionQueue` / `cumulativeTotals` / `nextRound` / `phaseStartedAt` / `startedAt` / `finishedAt` / `currentQuestion.tags`

`hostUid`（ルールのホスト判定）と `phaseStartedAt`（タイムアウトの基準時刻）は用途も併記しました。網羅的な型・書き込み箇所の一覧は `docs/architecture.md` にあるため、そちらへの参照も張っています。

### 3. 状態遷移にタイムアウトを追記

#14（PR #21）で入ったホスト端末主導のタイムアウトが書かれておらず、「全員が回答したら遷移」しか読めない状態でした。「### タイムアウトによる遷移」節を追加し、以下を明記しています。

- **全員が提出しなくてもフェーズは進む**（1人の離席・通信断でゲームが止まらないようにするため）
- `answerSeconds` / `predictSeconds` ＋猶予3秒でホスト端末が確定させる
- 基準時刻は端末のローカル時計ではなく `phaseStartedAt`（サーバー時刻）
- 未提出者は当該ラウンドのスコア集計から除外される

### 4. CI の記述（スコープ外だが1行）

同じ「実装に追随していない」種類の誤りだったため、あわせて直しました。`.github/workflows/ci.yml` を確認したところ **`backend/test_questions_sync.py`**（#16 で追加）と JS lint が実行されていますが、README には書かれていませんでした。

## 受け入れ基準の検証

`grep` で機械的に確認しました。

| 基準 | 結果 |
|---|---|
| 「質問リスト（5問）」の見出しと5問の列挙が残っていない | ✅ |
| 36問と1ゲーム5問が区別して書かれている | ✅ |
| 質問文が README に重複していない | ✅ `shared/questions.json` 参照方式 |
| `hostUid` / `category` / `questionQueue` / `cumulativeTotals` / `nextRound` / `phaseStartedAt` が含まれる | ✅ 6項目とも確認 |
| 状態遷移にタイムアウトが記載されている | ✅ |
| `docs/architecture.md`（v3.0）と矛盾しない | ✅ |

## 補足

- 冒頭の「ゲームフロー」と Firestore の JSON 例に「犬を飼ったことがある？」が**例示として**1箇所ずつ残っています。質問の一覧ではなく書式の説明なので、重複管理には当たらないと判断しました
- 現在オープンな PR #25（#12 Web カテゴリ選択）は `backend/web/index.html` や `docs/architecture.md` を変更しますが、本 PR は `README.md` の1ファイルのみなので競合しません

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)
