### PR TITLE
ホスト離脱検知でルームを終了させる (Issue #15)

### DIFF
--- a/android/app/src/main/java/com/rokusoudo/hitokazu/MainActivity.kt
+++ b/android/app/src/main/java/com/rokusoudo/hitokazu/MainActivity.kt
@@ -8,6 +8,9 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.NavHost
@@ -27,6 +30,7 @@ object Routes {
     const val PREDICTING = "predicting"
     const val RESULT = "result"
     const val FINISHED = "finished"
+    const val HOST_LEFT = "host_left"
 }
 
 class MainActivity : ComponentActivity() {
@@ -44,6 +48,17 @@ class MainActivity : ComponentActivity() {
 
                 // 起動時のディープリンクを処理
                 handleInviteIntent(intent, vm)
+
+                // ホスト離脱によるルーム終了は、参加者がどの画面にいても割り込むため、
+                // 各画面個別のLaunchedEffectではなくここで一括して監視する（Issue #15）。
+                val uiState by vm.uiState.collectAsState()
+                LaunchedEffect(uiState.phase) {
+                    if (uiState.phase == GamePhase.HOST_LEFT) {
+                        navController.navigate(Routes.HOST_LEFT) {
+                            popUpTo(Routes.HOME)
+                        }
+                    }
+                }
 
                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
                     NavHost(
@@ -108,6 +123,16 @@ class MainActivity : ComponentActivity() {
                                 onFinished = {
                                     navController.navigate(Routes.FINISHED) {
                                         popUpTo(Routes.HOME)
+                                    }
+                                },
+                            )
+                        }
+                        composable(Routes.HOST_LEFT) {
+                            HostLeftScreen(
+                                onLeaveRoom = {
+                                    vm.resetGame()
+                                    navController.navigate(Routes.HOME) {
+                                        popUpTo(Routes.HOME) { inclusive = true }
                                     }
                                 },
                             )

--- a/android/app/src/main/java/com/rokusoudo/hitokazu/data/firebase/FirebaseRepository.kt
+++ b/android/app/src/main/java/com/rokusoudo/hitokazu/data/firebase/FirebaseRepository.kt
@@ -44,6 +44,9 @@ class FirebaseRepository {
                 "currentQuestion" to null,
                 "category" to category.name,
                 "createdAt" to FieldValue.serverTimestamp(),
+                // 参加者が join した直後からホスト離脱判定の基準を持てるよう、作成時点でも書いておく
+                // （初回の定期ハートビートが届くまでの間、判定対象がnullで判定をスキップされる隙間を埋める）。
+                "hostHeartbeatAt" to FieldValue.serverTimestamp(),
             )
         ).await()
 
@@ -225,6 +228,29 @@ class FirebaseRepository {
         val answers = roundRef.collection("answers").get().await()
 
         finalizeRound(roomRef, roomData, currentRound, answers.documents)
+    }
+
+    // ── ホストのハートビート送信（ホスト端末が定期的に呼び出す） ──
+    // 一定間隔でルームドキュメントに serverTimestamp を書き込む。参加者端末はこの値の
+    // 更新が止まったことをもってホスト離脱と判定する（Issue #15）。
+    suspend fun sendHostHeartbeat(roomId: String): Result<Unit> = runCatching {
+        db.collection("rooms").document(roomId).update(
+            mapOf("hostHeartbeatAt" to FieldValue.serverTimestamp())
+        ).await()
+    }
+
+    // ── ホスト離脱によるルーム終了（参加者端末が呼び出す） ──
+    // hostHeartbeatAt の更新が閾値時間止まったと判定した参加者端末が呼び出す。
+    // すでにゲームが終了・確定済み（FINISHED/HOST_LEFT）の場合は何もしない
+    // （古いハートビート監視タイマーが後から発火した場合の二重確定を防ぐ）。
+    suspend fun terminateRoomHostLeft(roomId: String): Result<Unit> = runCatching {
+        val roomRef = db.collection("rooms").document(roomId)
+        val roomData = roomRef.get().await().data ?: return@runCatching
+
+        val status = roomData["status"] as? String
+        if (status == "FINISHED" || status == "HOST_LEFT") return@runCatching
+
+        roomRef.update(mapOf("status" to "HOST_LEFT")).await()
     }
 
     // ── 次のラウンドへ進む（ホストが呼び出す） ─────────────

--- a/android/app/src/main/java/com/rokusoudo/hitokazu/data/model/Models.kt
+++ b/android/app/src/main/java/com/rokusoudo/hitokazu/data/model/Models.kt
@@ -61,7 +61,10 @@ data class Player(
 )
 
 enum class GamePhase {
-    WAITING, ANSWERING, PREDICTING, RESULT, FINISHED
+    WAITING, ANSWERING, PREDICTING, RESULT, FINISHED,
+    // ホスト端末のハートビート（hostHeartbeatAt）が一定時間更新されなくなったことを
+    // 参加者端末が検知し、ルームを終了させたときの状態（Issue #15）。
+    HOST_LEFT
 }
 
 // ── Firestore Snapshot ────────────────────────────────────────
@@ -77,6 +80,9 @@ data class RoomSnapshot(
     // 現在のフェーズ（ANSWERING/PREDICTING）が開始したサーバー時刻（epoch millis）。
     // タイムアウト判定はこの値を基準に行う（端末時計や監視開始タイミングに依存させないため）。
     val phaseStartedAtMillis: Long?,
+    // ホスト端末が最後にハートビートを書き込んだサーバー時刻（epoch millis）。
+    // 参加者端末はこの値の更新が一定時間止まったことをもってホスト離脱と判定する（Issue #15）。
+    val hostHeartbeatAtMillis: Long?,
 ) {
     companion object {
         @Suppress("UNCHECKED_CAST")
@@ -114,6 +120,7 @@ data class RoomSnapshot(
                 } ?: emptyList()
 
             val phaseStartedAtMillis = (data["phaseStartedAt"] as? com.google.firebase.Timestamp)?.toDate()?.time
+            val hostHeartbeatAtMillis = (data["hostHeartbeatAt"] as? com.google.firebase.Timestamp)?.toDate()?.time
 
             return RoomSnapshot(
                 status = phase,
@@ -124,6 +131,7 @@ data class RoomSnapshot(
                 roundScores = parseScores("roundScores"),
                 finalScores = parseScores("finalScores"),
                 phaseStartedAtMillis = phaseStartedAtMillis,
+                hostHeartbeatAtMillis = hostHeartbeatAtMillis,
             )
         }
     }

--- a/android/app/src/main/java/com/rokusoudo/hitokazu/ui/screens/HostLeftScreen.kt
+++ b/android/app/src/main/java/com/rokusoudo/hitokazu/ui/screens/HostLeftScreen.kt
@@ -1,0 +1,54 @@
+package com.rokusoudo.hitokazu.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+// ホストが離脱（アプリ強制終了・通信断・バックグラウンド遷移など）したことを検知し、
+// ルームが HOST_LEFT へ遷移した際に残った参加者に表示する画面（Issue #15）。
+@Composable
+fun HostLeftScreen(
+    onLeaveRoom: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(text = "⚠️", fontSize = 48.sp)
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(
+            text = "ルームを終了しました",
+            fontSize = 24.sp,
+            fontWeight = FontWeight.Bold,
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Text(
+            text = "ホストが離脱したためルームを終了しました",
+            fontSize = 16.sp,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f),
+        )
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        Button(
+            onClick = onLeaveRoom,
+            modifier = Modifier.fillMaxWidth().height(52.dp),
+        ) {
+            Text("トップに戻る", fontSize = 16.sp)
+        }
+    }
+}

--- a/android/app/src/main/java/com/rokusoudo/hitokazu/viewmodel/GameViewModel.kt
+++ b/android/app/src/main/java/com/rokusoudo/hitokazu/viewmodel/GameViewModel.kt
@@ -8,6 +8,7 @@ import com.rokusoudo.hitokazu.data.model.*
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
 data class GameUiState(
@@ -32,6 +33,13 @@ data class GameUiState(
 // 回答・予測フェーズのタイムアウト猶予秒数（通信遅延・端末クロックのズレを吸収するバッファ）
 private const val TIMEOUT_GRACE_SECONDS = 3
 
+// ホスト端末がルームドキュメントにハートビートを書き込む間隔（秒）。
+// 参加者端末はこの3倍の時間ハートビートが更新されなければホスト離脱とみなす。
+// 例: 15秒間隔・5ラウンド(1ラウンド50秒程度)＝約5分のゲームで書き込み回数は約20回。
+// Firestore無料枠（書き込み2万回/日）に対して十分小さい。
+private const val HOST_HEARTBEAT_INTERVAL_SECONDS = 15L
+private const val HOST_HEARTBEAT_TIMEOUT_SECONDS = HOST_HEARTBEAT_INTERVAL_SECONDS * 3
+
 class GameViewModel : ViewModel() {
 
     private val repo = FirebaseRepository()
@@ -43,10 +51,16 @@ class GameViewModel : ViewModel() {
     private var autoAdvanceJob: Job? = null
     private var answeringTimeoutJob: Job? = null
     private var predictingTimeoutJob: Job? = null
+    private var hostHeartbeatJob: Job? = null
+    private var hostLeftCheckJob: Job? = null
 
     // 直近でタイムアウト監視をスケジュールした（フェーズ, ラウンド, フェーズ開始時刻）の組。
     // 同じ組に対して重複してタイマーを仕込まないようにするためのガード。
     private var lastScheduledTimeoutKey: String? = null
+
+    // 直近でホスト離脱監視をスケジュールしたhostHeartbeatAtMillisの値。
+    // 同じ値に対して重複してタイマーを仕込まないようにするためのガード。
+    private var lastScheduledHeartbeatAt: Long? = null
 
     // ── ルーム作成（ホスト） ──────────────────────────────────
     fun createRoom(hostName: String, category: QuestionCategory = QuestionCategory.ALL) {
@@ -131,6 +145,12 @@ class GameViewModel : ViewModel() {
 
     // ── Firestoreリアルタイム監視 ─────────────────────────────
     private fun startObserving(roomId: String) {
+        // ホスト端末は観測開始と同時に定期ハートビートの送信を始める（フェーズを問わず、
+        // 待合室段階からのホスト離脱も検知できるようにするため）。
+        if (_uiState.value.isHost) {
+            startHostHeartbeat(roomId)
+        }
+
         roomObserverJob?.cancel()
         roomObserverJob = viewModelScope.launch {
             repo.observeRoom(roomId).collect { snapshot ->
@@ -182,6 +202,17 @@ class GameViewModel : ViewModel() {
                         lastScheduledTimeoutKey = null
                     }
                 }
+
+                // ゲームが終了・確定した場合、ホストのハートビート送信も止める（無駄な書き込みを避ける）。
+                if (_uiState.value.isHost &&
+                    (snapshot.status == GamePhase.FINISHED || snapshot.status == GamePhase.HOST_LEFT)
+                ) {
+                    hostHeartbeatJob?.cancel()
+                    hostHeartbeatJob = null
+                }
+
+                // 参加者端末はホストのハートビート停止を監視し、離脱を検知したらルームを終了させる。
+                scheduleHostLeftCheck(roomId, snapshot)
             }
         }
 
@@ -190,6 +221,47 @@ class GameViewModel : ViewModel() {
             repo.observePlayers(roomId).collect { players ->
                 _uiState.update { it.copy(players = players) }
             }
+        }
+    }
+
+    // ── ホストのハートビート定期送信をスケジュール（ホストのみ） ──
+    private fun startHostHeartbeat(roomId: String) {
+        hostHeartbeatJob?.cancel()
+        hostHeartbeatJob = viewModelScope.launch {
+            while (isActive) {
+                repo.sendHostHeartbeat(roomId)
+                    .onFailure { Log.e("GameViewModel", "sendHostHeartbeat failed", it) }
+                delay(HOST_HEARTBEAT_INTERVAL_SECONDS * 1000L)
+            }
+        }
+    }
+
+    // ── ホスト離脱監視をスケジュール（参加者のみ） ──────────
+    // hostHeartbeatAtが更新されるたびに監視タイマーを仕込み直す（ウォッチドッグ方式）。
+    // 次の更新が来る前にタイマーが尽きたら、ホストが離脱したとみなしルームを終了させる。
+    private fun scheduleHostLeftCheck(roomId: String, snapshot: RoomSnapshot) {
+        if (_uiState.value.isHost) return
+
+        if (snapshot.status == GamePhase.FINISHED || snapshot.status == GamePhase.HOST_LEFT) {
+            hostLeftCheckJob?.cancel()
+            hostLeftCheckJob = null
+            lastScheduledHeartbeatAt = null
+            return
+        }
+
+        // 初回のハートビートが届くまでは判定しない（createRoom時に書き込まれるため、
+        // 通常はルーム参加直後から値が存在する）。
+        val heartbeatAt = snapshot.hostHeartbeatAtMillis ?: return
+        if (lastScheduledHeartbeatAt == heartbeatAt) return
+        lastScheduledHeartbeatAt = heartbeatAt
+
+        val deadline = heartbeatAt + HOST_HEARTBEAT_TIMEOUT_SECONDS * 1000L
+        hostLeftCheckJob?.cancel()
+        hostLeftCheckJob = viewModelScope.launch {
+            val waitMs = deadline - System.currentTimeMillis()
+            if (waitMs > 0) delay(waitMs)
+            repo.terminateRoomHostLeft(roomId)
+                .onFailure { Log.e("GameViewModel", "terminateRoomHostLeft failed", it) }
         }
     }
 
@@ -239,9 +311,12 @@ class GameViewModel : ViewModel() {
         autoAdvanceJob?.cancel()
         answeringTimeoutJob?.cancel()
         predictingTimeoutJob?.cancel()
+        hostHeartbeatJob?.cancel()
+        hostLeftCheckJob?.cancel()
         roomObserverJob?.cancel()
         playerObserverJob?.cancel()
         lastScheduledTimeoutKey = null
+        lastScheduledHeartbeatAt = null
         _uiState.value = GameUiState()
     }
 
@@ -263,6 +338,8 @@ class GameViewModel : ViewModel() {
         autoAdvanceJob?.cancel()
         answeringTimeoutJob?.cancel()
         predictingTimeoutJob?.cancel()
+        hostHeartbeatJob?.cancel()
+        hostLeftCheckJob?.cancel()
         roomObserverJob?.cancel()
         playerObserverJob?.cancel()
     }

--- a/backend/rules-tests/gameflow.test.mjs
+++ b/backend/rules-tests/gameflow.test.mjs
@@ -11,7 +11,7 @@
 import { readFileSync } from 'node:fs';
 import { after, before, describe, it } from 'node:test';
 import assert from 'node:assert';
-import { assertSucceeds, initializeTestEnvironment } from '@firebase/rules-unit-testing';
+import { assertFails, assertSucceeds, initializeTestEnvironment } from '@firebase/rules-unit-testing';
 import { doc, getDoc, setDoc, updateDoc, collection, getDocs } from 'firebase/firestore';
 
 const HOST = 'flow-host';
@@ -146,5 +146,65 @@ describe('実ゲームフロー（クライアント権限・ルール適用下�
     );
     const room = await getDoc(doc(db, `rooms/${ROOM}`));
     assert.strictEqual(room.data().status, 'FINISHED');
+  });
+});
+
+// Issue #15: ホスト離脱（ハートビート停止）によるルーム終了。
+// FLOWROOM は上のテストで既に FINISHED まで進めているため、
+// 意味のない状態遷移にならないよう別ルームを使う。
+describe('ホスト離脱によるルーム終了（Issue #15）', () => {
+  const HB_ROOM = 'HBFLOWROOM';
+
+  it('1) ホストがルーム作成時と定期送信でハートビートを書き込める', async () => {
+    const hostDb = testEnv.authenticatedContext(HOST).firestore();
+    await assertSucceeds(
+      setDoc(doc(hostDb, `rooms/${HB_ROOM}`), {
+        hostName: 'ホスト太郎',
+        hostUid: HOST,
+        status: 'WAITING',
+        currentRound: 0,
+        totalRounds: 5,
+        category: 'ALL',
+        hostHeartbeatAt: new Date(),
+      }),
+    );
+    await assertSucceeds(
+      setDoc(doc(hostDb, `rooms/${HB_ROOM}/players/${HOST}`), { nickname: 'ホスト太郎', isHost: true }),
+    );
+
+    const p2Db = testEnv.authenticatedContext(P2).firestore();
+    await assertSucceeds(
+      setDoc(doc(p2Db, `rooms/${HB_ROOM}/players/${P2}`), { nickname: P2, isHost: false }),
+    );
+
+    // GameViewModel.sendHostHeartbeat / index.html sendHostHeartbeat と同じ操作（定期更新）
+    await assertSucceeds(
+      updateDoc(doc(hostDb, `rooms/${HB_ROOM}`), { hostHeartbeatAt: new Date() }),
+    );
+  });
+
+  it('2) ホスト以外の参加者が、ハートビート停止を検知してルームをHOST_LEFTにできる', async () => {
+    // FirebaseRepository.terminateRoomHostLeft / index.html terminateRoomHostLeft と同じ操作。
+    // 実行者はホストではなく、離脱を検知した参加者側。
+    const p2Db = testEnv.authenticatedContext(P2).firestore();
+    const before = await assertSucceeds(getDoc(doc(p2Db, `rooms/${HB_ROOM}`)));
+    assert.strictEqual(before.data().status, 'WAITING');
+
+    await assertSucceeds(
+      updateDoc(doc(p2Db, `rooms/${HB_ROOM}`), { status: 'HOST_LEFT' }),
+    );
+
+    const after = await getDoc(doc(p2Db, `rooms/${HB_ROOM}`));
+    assert.strictEqual(after.data().status, 'HOST_LEFT');
+  });
+
+  it('3) 部外者はハートビートもHOST_LEFT遷移も書き込めない', async () => {
+    const outsiderDb = testEnv.authenticatedContext('hb-outsider').firestore();
+    await assertFails(
+      updateDoc(doc(outsiderDb, `rooms/${HB_ROOM}`), { hostHeartbeatAt: new Date() }),
+    );
+    await assertFails(
+      updateDoc(doc(outsiderDb, `rooms/${HB_ROOM}`), { status: 'HOST_LEFT' }),
+    );
   });
 });

--- a/backend/web/index.html
+++ b/backend/web/index.html
@@ -172,6 +172,13 @@
     </div>
     <button class="btn-primary" onclick="resetGame()" style="margin-top:16px">トップに戻る</button>
   </div>
+
+  <!-- ホスト離脱によるルーム終了画面 -->
+  <div id="screen-host-left" class="screen">
+    <h2>ルームを終了しました</h2>
+    <p class="info" style="text-align:center">ホストが離脱したためルームを終了しました</p>
+    <button class="btn-primary" onclick="resetGame()" style="margin-top:16px">トップに戻る</button>
+  </div>
 </div>
 
 <script type="module">
@@ -197,6 +204,13 @@
   // 回答・予測フェーズのタイムアウト猶予秒数（通信遅延・端末クロックのズレを吸収するバッファ）
   const TIMEOUT_GRACE_SECONDS = 3;
 
+  // ホスト端末がルームドキュメントにハートビートを書き込む間隔（秒）。
+  // 参加者端末はこの3倍の時間ハートビートが更新されなければホスト離脱とみなす。
+  // 例: 15秒間隔・5ラウンド(1ラウンド50秒程度)＝約5分のゲームで書き込み回数は約20回。
+  // Firestore無料枠（書き込み2万回/日）に対して十分小さい（Issue #15）。
+  const HOST_HEARTBEAT_INTERVAL_SECONDS = 15;
+  const HOST_HEARTBEAT_TIMEOUT_SECONDS = HOST_HEARTBEAT_INTERVAL_SECONDS * 3;
+
   let state = {
     uid: null,
     roomId: null,
@@ -211,9 +225,13 @@
     autoAdvanceTimer: null,
     answeringTimeoutTimer: null,
     predictingTimeoutTimer: null,
+    hostHeartbeatInterval: null,
+    hostLeftCheckTimer: null,
     // 直近でタイムアウト監視をスケジュールした（フェーズ:ラウンド:フェーズ開始時刻）の組。
     // 同じ組に対して重複してタイマーを仕込まないようにするためのガード。
     lastScheduledTimeoutKey: null,
+    // 直近でホスト離脱監視をスケジュールしたhostHeartbeatAtの値（ミリ秒）。
+    lastScheduledHeartbeatAt: null,
   };
 
   // 匿名認証
@@ -267,6 +285,9 @@
       hostName, hostUid: state.uid,
       status: 'WAITING', currentRound: 0, totalRounds: 5,
       currentQuestion: null, category, createdAt: serverTimestamp(),
+      // 参加者が join した直後からホスト離脱判定の基準を持てるよう、作成時点でも書いておく
+      // （初回の定期ハートビートが届くまでの間、判定対象がnullで判定をスキップされる隙間を埋める）。
+      hostHeartbeatAt: serverTimestamp(),
     });
     await setDoc(doc(db, 'rooms', roomId, 'players', state.uid), {
       nickname: hostName, isHost: true, joinedAt: serverTimestamp(),
@@ -303,6 +324,66 @@
     document.getElementById('guest-waiting-msg').style.display = state.isHost ? 'none' : 'block';
     showScreen('waiting');
     startObserving();
+    // ホスト端末は観測開始と同時に定期ハートビートの送信を始める（フェーズを問わず、
+    // 待合室段階からのホスト離脱も検知できるようにするため）。
+    if (state.isHost) startHostHeartbeat();
+  }
+
+  // ── ホストのハートビート定期送信（ホストのみ） ──────────
+  async function sendHostHeartbeat() {
+    try {
+      await updateDoc(doc(db, 'rooms', state.roomId), { hostHeartbeatAt: serverTimestamp() });
+    } catch (err) {
+      console.error('sendHostHeartbeat failed', err);
+    }
+  }
+
+  function startHostHeartbeat() {
+    clearInterval(state.hostHeartbeatInterval);
+    sendHostHeartbeat();
+    state.hostHeartbeatInterval = setInterval(sendHostHeartbeat, HOST_HEARTBEAT_INTERVAL_SECONDS * 1000);
+  }
+
+  // ── ホスト離脱によるルーム終了（参加者のみ呼び出し） ──────
+  // hostHeartbeatAt の更新が閾値時間止まったと判定した参加者端末が呼び出す。
+  // すでにゲームが終了・確定済み（FINISHED/HOST_LEFT）の場合は何もしない
+  // （古いハートビート監視タイマーが後から発火した場合の二重確定を防ぐ）。
+  async function terminateRoomHostLeft() {
+    const roomRef = doc(db, 'rooms', state.roomId);
+    const roomSnap = await getDoc(roomRef);
+    if (!roomSnap.exists()) return;
+    const status = roomSnap.data().status;
+    if (status === 'FINISHED' || status === 'HOST_LEFT') return;
+    await updateDoc(roomRef, { status: 'HOST_LEFT' });
+  }
+
+  // ── ホスト離脱監視をスケジュール（参加者のみ） ────────────
+  // hostHeartbeatAtが更新されるたびに監視タイマーを仕込み直す（ウォッチドッグ方式）。
+  // 次の更新が来る前にタイマーが尽きたら、ホストが離脱したとみなしルームを終了させる。
+  function scheduleHostLeftCheck(data) {
+    if (state.isHost) return;
+
+    if (data.status === 'FINISHED' || data.status === 'HOST_LEFT') {
+      clearTimeout(state.hostLeftCheckTimer);
+      state.hostLeftCheckTimer = null;
+      state.lastScheduledHeartbeatAt = null;
+      return;
+    }
+
+    const heartbeatAtMs = (data.hostHeartbeatAt && typeof data.hostHeartbeatAt.toMillis === 'function')
+      ? data.hostHeartbeatAt.toMillis()
+      : null;
+    // 初回のハートビートが届くまでは判定しない（createRoom時に書き込まれるため、
+    // 通常はルーム参加直後から値が存在する）。
+    if (heartbeatAtMs == null) return;
+    if (state.lastScheduledHeartbeatAt === heartbeatAtMs) return;
+    state.lastScheduledHeartbeatAt = heartbeatAtMs;
+
+    const deadline = heartbeatAtMs + HOST_HEARTBEAT_TIMEOUT_SECONDS * 1000;
+    clearTimeout(state.hostLeftCheckTimer);
+    state.hostLeftCheckTimer = setTimeout(() => {
+      terminateRoomHostLeft().catch(err => console.error('terminateRoomHostLeft failed', err));
+    }, Math.max(0, deadline - Date.now()));
   }
 
   function startObserving() {
@@ -329,11 +410,18 @@
       const data = snap.data();
       const phase = data.status;
 
-      // ホストのタイムアウト監視は、画面再描画の間引き（下の早期return）とは独立に
-      // 毎スナップショットで評価する。serverTimestamp()確定時に発火するスナップショットは
-      // phase/currentRoundが変化しないため、間引きされると基準時刻を取得し損ねるため。
+      // ホストのタイムアウト監視・ホスト離脱監視は、画面再描画の間引き（下の早期return）とは
+      // 独立に毎スナップショットで評価する。serverTimestamp()確定時に発火するスナップショットは
+      // phase/currentRoundが変化しないため、間引きされると基準時刻を取得し損ねる
+      // （ハートビート書き込みはまさにこのケース＝phase・roundを一切変えない）。
       if (state.isHost) {
         scheduleHostTimeouts(data);
+        if (phase === 'FINISHED' || phase === 'HOST_LEFT') {
+          clearInterval(state.hostHeartbeatInterval);
+          state.hostHeartbeatInterval = null;
+        }
+      } else {
+        scheduleHostLeftCheck(data);
       }
 
       if (phase === state.currentPhase && data.currentRound === state.currentRound) return;
@@ -354,6 +442,8 @@
         }
       } else if (phase === 'FINISHED') {
         renderFinished(data);
+      } else if (phase === 'HOST_LEFT') {
+        renderHostLeft();
       }
     });
   }
@@ -718,15 +808,22 @@
     showScreen('finished');
   }
 
+  function renderHostLeft() {
+    showScreen('host-left');
+  }
+
   function resetGame() {
     if (state.roomUnsub) state.roomUnsub();
     if (state.playersUnsub) state.playersUnsub();
     clearTimeout(state.autoAdvanceTimer);
     clearTimeout(state.answeringTimeoutTimer);
     clearTimeout(state.predictingTimeoutTimer);
+    clearInterval(state.hostHeartbeatInterval);
+    clearTimeout(state.hostLeftCheckTimer);
     state = { ...state, roomId: null, isHost: false, nickname: '', selectedAnswer: null,
       predictionSent: false, currentPhase: null, currentRound: 0, roomUnsub: null, playersUnsub: null,
-      answeringTimeoutTimer: null, predictingTimeoutTimer: null, lastScheduledTimeoutKey: null };
+      answeringTimeoutTimer: null, predictingTimeoutTimer: null, lastScheduledTimeoutKey: null,
+      hostHeartbeatInterval: null, hostLeftCheckTimer: null, lastScheduledHeartbeatAt: null };
     showScreen('home');
   }
 </script>


### PR DESCRIPTION
## 概要

#14 で導入したホスト端末主導のタイムアウト方式には、ホスト自身が離脱（アプリ強制終了・通信断・バックグラウンド遷移など）した場合に誰もフェーズを確定できなくなる欠陥があった。本PRはこれを解消する。

## 実装内容（代表確定済み方式に準拠）

- **検知方式**: ホスト端末がルームドキュメントに `hostHeartbeatAt`（serverTimestamp）を15秒間隔で書き込む。参加者端末はこの値が45秒（3倍）更新されないことをもってホスト離脱と判定する（判定はサーバー時刻基準、端末ローカル時刻に依存しない）。
- **離脱検知時の挙動**: 検知した参加者端末がルームの `status` を新設の `HOST_LEFT` に更新し、残った参加者全員に「ホストが離脱したためルームを終了しました」を表示、トップに戻れるようにする。代替ホスト昇格は不採用（issue記載の通り）。
- Android・Web(JS) の両クライアントに同一ロジックを実装。Firestoreセキュリティルールは変更不要（`isPlayer()` が既にルーム更新を許可しており、rules-testsの既存テストで確認済み）。

### 無料枠への配慮

15秒間隔 ≈ 毎分4回の書き込み。1ゲーム（5ラウンド、数分程度）で書き込み回数は概算20〜40回程度で、Firestore無料枠（書き込み2万回/日）に対して十分小さい。

## 変更ファイル

- `android/app/src/main/java/com/rokusoudo/hitokazu/data/model/Models.kt`: `GamePhase.HOST_LEFT` 追加、`RoomSnapshot.hostHeartbeatAtMillis` 追加
- `android/app/src/main/java/com/rokusoudo/hitokazu/data/firebase/FirebaseRepository.kt`: `sendHostHeartbeat` / `terminateRoomHostLeft` 追加、`createRoom` で初期ハートビートを書き込み
- `android/app/src/main/java/com/rokusoudo/hitokazu/viewmodel/GameViewModel.kt`: ホストの定期ハートビート送信、参加者のウォッチドッグ監視（#14と同じ再スケジュール方式）
- `android/app/src/main/java/com/rokusoudo/hitokazu/ui/screens/HostLeftScreen.kt`: 新規。終了メッセージ画面
- `android/app/src/main/java/com/rokusoudo/hitokazu/MainActivity.kt`: `HOST_LEFT` ルート追加、どの画面からでも割り込めるグローバル監視を追加
- `backend/web/index.html`: Android側と同等のロジック（ハートビート送信・ウォッチドッグ・終了画面）を追加
- `backend/rules-tests/gameflow.test.mjs`: ホストのハートビート書き込み・参加者によるHOST_LEFT遷移・部外者拒否を検証するテストを追加

## テスト結果

- `./gradlew :app:compileDebugKotlin` → BUILD SUCCESSFUL
- `python3 backend/test_logic.py` → 全テスト合格（既存ロジックに影響なし）
- `python3 backend/test_questions_sync.py` → 全テスト合格
- `npm --prefix backend/rules-tests run test:emulator`（Firestore Emulator）→ 35件全て合格（既存32件 + 今回追加3件）

## 未対応（スコープ外）

- issueの背景で触れている「playersドキュメントを削除する退室処理」自体は今回のACに含まれないため実装していない（「退室できる」は既存トップに戻るボタンと同じ、ローカルリセット＋ホーム遷移で満たしている）。

Closes #15
