### PR TITLE
終了画面の「もう一度遊ぶ」で同一ルームのまま再戦できるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Android / ブラウザ
   "cumulativeTotals": { "<playerId>": 240 },
   "nextRound": 2,
   "phaseStartedAt": "timestamp",
+  "gameCount": 1,
   "createdAt": "timestamp",
   "startedAt": "timestamp",
   "finishedAt": "timestamp"
@@ -214,13 +215,14 @@ Android / ブラウザ
 ## ゲームの状態遷移
 
 ```
-WAITING → ANSWERING → PREDICTING → RESULT → ANSWERING → ...→ FINISHED
+WAITING → ANSWERING → PREDICTING → RESULT → ANSWERING → ...→ FINISHED → (再戦) WAITING
 ```
 
 - 全員が回答したら自動で `PREDICTING` へ遷移
 - 全員が予測したら自動で `RESULT` へ遷移
 - ホストが10秒後に自動で次ラウンド（`ANSWERING`）へ進行
 - 最終ラウンド終了後は `FINISHED` へ遷移
+- ホストが終了画面で「もう一度遊ぶ」を押すと、同一ルームのまま `WAITING` に戻る（参加者はルームID再入力・QR再スキャン不要）。「トップに戻る」はルームを離脱するだけで `WAITING` には戻らない。詳細は [docs/architecture.md](docs/architecture.md#フェーズ状態遷移)
 
 ### タイムアウトによる遷移
 

--- a/android/app/src/main/java/com/rokusoudo/hitokazu/MainActivity.kt
+++ b/android/app/src/main/java/com/rokusoudo/hitokazu/MainActivity.kt
@@ -8,6 +8,8 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.NavHost
@@ -113,18 +115,28 @@ class MainActivity : ComponentActivity() {
                             )
                         }
                         composable(Routes.FINISHED) {
+                            val finishedUiState by vm.uiState.collectAsState()
                             FinishedScreen(
                                 viewModel = vm,
                                 onRestart = {
+                                    // restartGame() は roomId/observer を維持したまま status を
+                                    // WAITING に戻す。実際の画面遷移は onWaitingRoom（下記）で行う。
+                                    vm.restartGame()
+                                },
+                                onHome = {
+                                    // 「トップに戻る」は従来どおりルームから離脱してホーム画面へ戻す。
+                                    // onRestart（再戦）とは明確に別の挙動（Issue #17）。
                                     vm.resetGame()
                                     navController.navigate(Routes.HOME) {
                                         popUpTo(Routes.HOME) { inclusive = true }
                                     }
                                 },
-                                onHome = {
-                                    vm.resetGame()
-                                    navController.navigate(Routes.HOME) {
-                                        popUpTo(Routes.HOME) { inclusive = true }
+                                onWaitingRoom = {
+                                    // ホストは QR表示/開始画面へ、参加者は待合室へ。
+                                    // どちらも既存のANSWERING検知でゲーム開始に追従する。
+                                    val destination = if (finishedUiState.isHost) Routes.QR_DISPLAY else Routes.WAITING_ROOM
+                                    navController.navigate(destination) {
+                                        popUpTo(Routes.HOME)
                                     }
                                 },
                             )

--- a/android/app/src/main/java/com/rokusoudo/hitokazu/data/firebase/FirebaseRepository.kt
+++ b/android/app/src/main/java/com/rokusoudo/hitokazu/data/firebase/FirebaseRepository.kt
@@ -43,6 +43,9 @@ class FirebaseRepository {
                 "totalRounds" to TOTAL_ROUNDS_PER_GAME,
                 "currentQuestion" to null,
                 "category" to category.name,
+                // 同一ルームでの再戦（restartGame）ごとにインクリメントする世代番号。
+                // rounds/{gameCount}_{round} のドキュメントIDに使い、前ゲームの回答と衝突させない（Issue #17）。
+                "gameCount" to 1L,
                 "createdAt" to FieldValue.serverTimestamp(),
             )
         ).await()
@@ -91,10 +94,36 @@ class FirebaseRepository {
         val roomSnap = db.collection("rooms").document(roomId).get().await()
         val categoryStr = roomSnap.getString("category")
         val category = QuestionCategory.fromString(categoryStr)
+        // 再戦（restartGame）直後は前ゲーム最終問題のIDが入っている（Issue #17）。
+        val avoidQuestionId = roomSnap.getString("lastPlayedQuestionId")
 
         val filtered = QUESTIONS.filter { q -> q.tags.any { it in category.tags } }
         val pool = if (filtered.isEmpty()) QUESTIONS else filtered
-        val questionQueue = pool.shuffled().take(TOTAL_ROUNDS_PER_GAME)
+        var questionQueue = pool.shuffled().take(TOTAL_ROUNDS_PER_GAME)
+
+        // 再戦時、前ゲーム最後の質問がそのまま1問目にならないよう、可能なら入れ替える。
+        if (avoidQuestionId != null && questionQueue.firstOrNull()?.questionId == avoidQuestionId) {
+            val altIndex = questionQueue.indexOfFirst { it.questionId != avoidQuestionId }
+            questionQueue = if (altIndex > 0) {
+                questionQueue.toMutableList().apply {
+                    val tmp = this[0]
+                    this[0] = this[altIndex]
+                    this[altIndex] = tmp
+                }
+            } else {
+                // キュー内が全て同じ質問（プールが極小）の場合は、プール全体から差し替えを探す
+                val replacement = pool.firstOrNull { candidate ->
+                    candidate.questionId != avoidQuestionId &&
+                        questionQueue.none { it.questionId == candidate.questionId }
+                }
+                if (replacement != null) {
+                    listOf(replacement) + questionQueue.drop(1)
+                } else {
+                    questionQueue // 代替なし。避けられないので諦める
+                }
+            }
+        }
+
         val firstQuestion = questionQueue[0]
         db.collection("rooms").document(roomId).update(
             mapOf(
@@ -105,6 +134,7 @@ class FirebaseRepository {
                 "currentQuestion" to firstQuestion.toMap(),
                 "startedAt" to FieldValue.serverTimestamp(),
                 "phaseStartedAt" to FieldValue.serverTimestamp(),
+                "lastPlayedQuestionId" to FieldValue.delete(),
             )
         ).await()
     }
@@ -118,7 +148,8 @@ class FirebaseRepository {
         if (roomData["status"] != "ANSWERING") error("回答フェーズではありません")
 
         val currentRound = (roomData["currentRound"] as? Long)?.toInt() ?: error("ラウンド情報なし")
-        val roundRef = roomRef.collection("rounds").document(currentRound.toString())
+        val gameCount = (roomData["gameCount"] as? Long) ?: 1L
+        val roundRef = roomRef.collection("rounds").document(roundDocId(gameCount, currentRound))
         val answerRef = roundRef.collection("answers").document(playerId)
 
         if (answerRef.get().await().exists()) error("すでに回答済みです")
@@ -150,7 +181,8 @@ class FirebaseRepository {
         if (roomData["status"] != "ANSWERING") return@runCatching // すでに遷移済み
 
         val currentRound = (roomData["currentRound"] as? Long)?.toInt() ?: return@runCatching
-        val roundRef = roomRef.collection("rounds").document(currentRound.toString())
+        val gameCount = (roomData["gameCount"] as? Long) ?: 1L
+        val roundRef = roomRef.collection("rounds").document(roundDocId(gameCount, currentRound))
         val answers = roundRef.collection("answers").get().await()
 
         advanceToPredicting(roomRef, roomData, answers)
@@ -189,7 +221,8 @@ class FirebaseRepository {
         if (roomData["status"] != "PREDICTING") error("予測フェーズではありません")
 
         val currentRound = (roomData["currentRound"] as? Long)?.toInt() ?: error("ラウンド情報なし")
-        val roundRef = roomRef.collection("rounds").document(currentRound.toString())
+        val gameCount = (roomData["gameCount"] as? Long) ?: 1L
+        val roundRef = roomRef.collection("rounds").document(roundDocId(gameCount, currentRound))
         val answerRef = roundRef.collection("answers").document(playerId)
 
         answerRef.update(
@@ -221,10 +254,48 @@ class FirebaseRepository {
         if (roomData["status"] != "PREDICTING") return@runCatching // すでに確定済み
 
         val currentRound = (roomData["currentRound"] as? Long)?.toInt() ?: return@runCatching
-        val roundRef = roomRef.collection("rounds").document(currentRound.toString())
+        val gameCount = (roomData["gameCount"] as? Long) ?: 1L
+        val roundRef = roomRef.collection("rounds").document(roundDocId(gameCount, currentRound))
         val answers = roundRef.collection("answers").get().await()
 
         finalizeRound(roomRef, roomData, currentRound, answers.documents)
+    }
+
+    // ── 再戦（同一ルームを再利用してもう一度遊ぶ） ─────────
+    // 「もう一度遊ぶ」はホストのみが呼び出せる（FinishedScreen で isHost のみボタン表示）。
+    // status を WAITING に戻し、スコア・ラウンド状態をクリアする。category は引き継ぐ。
+    // gameCount をインクリメントすることで、次に始まるゲームの rounds/{gameCount}_{round}
+    // ドキュメントIDが前ゲームと衝突しなくなり、submitAnswer() の「すでに回答済みです」を防ぐ。
+    suspend fun restartGame(roomId: String): Result<Unit> = runCatching {
+        val roomRef = db.collection("rooms").document(roomId)
+        val roomData = roomRef.get().await().data ?: error("ルームが見つかりません")
+
+        if (roomData["status"] != "FINISHED") error("ゲーム終了後にのみ再戦できます")
+
+        val prevGameCount = (roomData["gameCount"] as? Long) ?: 1L
+        val lastQuestion = roomData["currentQuestion"] as? Map<*, *>
+        val lastQuestionId = lastQuestion?.get("questionId") as? String
+
+        val updates = mutableMapOf<String, Any?>(
+            "status" to "WAITING",
+            "currentRound" to 0,
+            "gameCount" to (prevGameCount + 1),
+            "questionQueue" to FieldValue.delete(),
+            "currentQuestion" to null,
+            "answerCounts" to emptyMap<String, Int>(),
+            "roundScores" to emptyList<Any>(),
+            "finalScores" to emptyList<Any>(),
+            "cumulativeTotals" to emptyMap<String, Int>(),
+            "nextRound" to FieldValue.delete(),
+            "restartedAt" to FieldValue.serverTimestamp(),
+        )
+        if (lastQuestionId != null) {
+            updates["lastPlayedQuestionId"] = lastQuestionId
+        } else {
+            updates["lastPlayedQuestionId"] = FieldValue.delete()
+        }
+
+        roomRef.update(updates).await()
     }
 
     // ── 次のラウンドへ進む（ホストが呼び出す） ─────────────
@@ -363,5 +434,9 @@ class FirebaseRepository {
 
 private fun calculateScore(actual: Int, predicted: Int): Int =
     maxOf(0, 100 - kotlin.math.abs(predicted - actual) * 20)
+
+// rounds サブコレクションのドキュメントID。gameCount を含めることで、restartGame() 後の
+// 2ゲーム目が前ゲームの rounds/{round}/answers と衝突しないようにする（Issue #17）。
+private fun roundDocId(gameCount: Long, round: Int): String = "${gameCount}_${round}"
 
 private const val TOTAL_ROUNDS_PER_GAME = 5

--- a/android/app/src/main/java/com/rokusoudo/hitokazu/ui/screens/FinishedScreen.kt
+++ b/android/app/src/main/java/com/rokusoudo/hitokazu/ui/screens/FinishedScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -13,6 +14,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.rokusoudo.hitokazu.data.model.GamePhase
 import com.rokusoudo.hitokazu.data.model.PlayerScore
 import com.rokusoudo.hitokazu.viewmodel.GameViewModel
 
@@ -21,9 +23,19 @@ fun FinishedScreen(
     viewModel: GameViewModel,
     onRestart: () -> Unit,
     onHome: () -> Unit,
+    onWaitingRoom: () -> Unit = {},
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val winner = uiState.scores.firstOrNull()
+
+    // ホストが「もう一度遊ぶ」を押すと restartGame() が status を WAITING に戻す。
+    // observeRoom 経由でその遷移を検知したら、参加者側も含めて全員が自動で待合室へ戻る
+    // （ルームID再入力・QR再スキャン不要にするための仕組み。Issue #17）。
+    LaunchedEffect(uiState.phase) {
+        if (uiState.phase == GamePhase.WAITING) {
+            onWaitingRoom()
+        }
+    }
 
     Column(
         modifier = Modifier

--- a/android/app/src/main/java/com/rokusoudo/hitokazu/viewmodel/GameViewModel.kt
+++ b/android/app/src/main/java/com/rokusoudo/hitokazu/viewmodel/GameViewModel.kt
@@ -110,6 +110,17 @@ class GameViewModel : ViewModel() {
         }
     }
 
+    // ── 再戦（ホストのみ・終了画面の「もう一度遊ぶ」） ────────
+    // resetGame() と異なり roomId/playerId/observer は維持する。
+    // observeRoom が FINISHED → WAITING への遷移を全端末に伝え、各画面がそれを検知して
+    // 待合室へ自動遷移する（参加者はルームID再入力・QR再スキャン不要）。
+    fun restartGame() {
+        viewModelScope.launch {
+            repo.restartGame(_uiState.value.roomId)
+                .onFailure { _uiState.update { it.copy(errorMessage = "再戦の開始に失敗しました") } }
+        }
+    }
+
     // ── 回答送信 ──────────────────────────────────────────────
     fun submitAnswer(answer: String) {
         val state = _uiState.value

--- a/backend/rules-tests/gameflow.test.mjs
+++ b/backend/rules-tests/gameflow.test.mjs
@@ -75,17 +75,19 @@ describe('実ゲームフロー（クライアント権限・ルール適用下�
       updateDoc(doc(db, `rooms/${ROOM}`), {
         status: 'ANSWERING',
         currentRound: 1,
+        gameCount: 1,
         currentQuestion: { questionId: 'q001', text: 'テスト質問', options: ['はい', 'いいえ'] },
       }),
     );
   });
 
+  // roundId は `{gameCount}_{round}`（Issue #17）。1ゲーム目・round=1 なので "1_1"。
   it('4) 全員が回答を送信できる', async () => {
     const answers = { [HOST]: 'はい', [P2]: 'いいえ', [P3]: 'はい' };
     for (const [uid, answer] of Object.entries(answers)) {
       const db = testEnv.authenticatedContext(uid).firestore();
       await assertSucceeds(
-        setDoc(doc(db, `rooms/${ROOM}/rounds/1/answers/${uid}`), { answer }),
+        setDoc(doc(db, `rooms/${ROOM}/rounds/1_1/answers/${uid}`), { answer }),
       );
     }
   });
@@ -93,7 +95,7 @@ describe('実ゲームフロー（クライアント権限・ルール適用下�
   it('5) 最後の回答者が集計して PREDICTING へ遷移できる', async () => {
     // finalizeRound と同様、ホストとは限らないプレイヤーが実行する
     const db = testEnv.authenticatedContext(P3).firestore();
-    const snap = await assertSucceeds(getDocs(collection(db, `rooms/${ROOM}/rounds/1/answers`)));
+    const snap = await assertSucceeds(getDocs(collection(db, `rooms/${ROOM}/rounds/1_1/answers`)));
     assert.strictEqual(snap.size, 3);
     await assertSucceeds(
       updateDoc(doc(db, `rooms/${ROOM}`), {
@@ -108,7 +110,7 @@ describe('実ゲームフロー（クライアント権限・ルール適用下�
     for (const [uid, prediction] of Object.entries(preds)) {
       const db = testEnv.authenticatedContext(uid).firestore();
       await assertSucceeds(
-        updateDoc(doc(db, `rooms/${ROOM}/rounds/1/answers/${uid}`), {
+        updateDoc(doc(db, `rooms/${ROOM}/rounds/1_1/answers/${uid}`), {
           prediction,
           targetOption: 'はい',
         }),
@@ -121,7 +123,7 @@ describe('実ゲームフロー（クライアント権限・ルール適用下�
     const db = testEnv.authenticatedContext(P3).firestore();
     for (const [uid, score] of [[HOST, 100], [P2, 80], [P3, 80]]) {
       await assertSucceeds(
-        updateDoc(doc(db, `rooms/${ROOM}/rounds/1/answers/${uid}`), {
+        updateDoc(doc(db, `rooms/${ROOM}/rounds/1_1/answers/${uid}`), {
           roundScore: score,
           totalScore: score,
         }),
@@ -146,5 +148,62 @@ describe('実ゲームフロー（クライアント権限・ルール適用下�
     );
     const room = await getDoc(doc(db, `rooms/${ROOM}`));
     assert.strictEqual(room.data().status, 'FINISHED');
+  });
+
+  // ── Issue #17: 再戦（restartGame） ──────────────────────────
+  // FirebaseRepository.restartGame() / index.html の restartGame() と同じ操作を
+  // クライアント権限で再現する。ホストが「もう一度遊ぶ」を押した想定。
+  it('9) ホストが再戦できる（FINISHED → WAITING、gameCountをインクリメント）', async () => {
+    const db = testEnv.authenticatedContext(HOST).firestore();
+    await assertSucceeds(
+      updateDoc(doc(db, `rooms/${ROOM}`), {
+        status: 'WAITING',
+        currentRound: 0,
+        gameCount: 2,
+        currentQuestion: null,
+        answerCounts: {},
+        roundScores: [],
+        finalScores: [],
+        cumulativeTotals: {},
+      }),
+    );
+    const room = await getDoc(doc(db, `rooms/${ROOM}`));
+    assert.strictEqual(room.data().status, 'WAITING');
+    assert.strictEqual(room.data().gameCount, 2);
+    assert.strictEqual(room.data().currentRound, 0);
+  });
+
+  it('10) 再戦後の2ゲーム目は round=1 でも前ゲームの回答と衝突しない（roundId に gameCount を含む）', async () => {
+    // 1ゲーム目の rounds/1_1/answers はテスト4で作成済み。2ゲーム目は rounds/2_1 を使うため、
+    // 同じ round=1 でも「すでに回答済みです」に相当する衝突が起きないことを確認する。
+    const hostDb = testEnv.authenticatedContext(HOST).firestore();
+    await assertSucceeds(
+      updateDoc(doc(hostDb, `rooms/${ROOM}`), {
+        status: 'ANSWERING',
+        currentRound: 1,
+        currentQuestion: { questionId: 'q002', text: 'テスト質問2', options: ['はい', 'いいえ'] },
+      }),
+    );
+
+    const answers = { [HOST]: 'はい', [P2]: 'いいえ', [P3]: 'はい' };
+    for (const [uid, answer] of Object.entries(answers)) {
+      const db = testEnv.authenticatedContext(uid).firestore();
+      // 1ゲーム目と同じ round=1 だが gameCount=2 のドキュメントへ書く
+      await assertSucceeds(
+        setDoc(doc(db, `rooms/${ROOM}/rounds/2_1/answers/${uid}`), { answer }),
+      );
+    }
+
+    // 1ゲーム目の rounds/1_1/answers はそのまま残っている（削除しない仕様）
+    const hostReadDb = testEnv.authenticatedContext(HOST).firestore();
+    const oldGameAnswers = await assertSucceeds(
+      getDocs(collection(hostReadDb, `rooms/${ROOM}/rounds/1_1/answers`)),
+    );
+    assert.strictEqual(oldGameAnswers.size, 3, '1ゲーム目のデータは削除されずに残る');
+
+    const newGameAnswers = await assertSucceeds(
+      getDocs(collection(hostReadDb, `rooms/${ROOM}/rounds/2_1/answers`)),
+    );
+    assert.strictEqual(newGameAnswers.size, 3, '2ゲーム目は独立したドキュメントに書き込める');
   });
 });

--- a/backend/test_game_flow.py
+++ b/backend/test_game_flow.py
@@ -245,9 +245,62 @@ snap = room_ref.get()
 check("status=FINISHED", snap.get("status") == "FINISHED")
 check("finalScores 保存", len(snap.get("finalScores")) == len(players))
 
+# ── TEST 9: 再戦（restartGame, Issue #17）────────────────────
+# FirebaseRepository.restartGame() と同じ操作を再現し、
+# 「2ゲーム目でも submitAnswer 相当の処理がすでに回答済みエラーにならない」
+# 「スコアが0から始まる」「カテゴリが引き継がれる」ことを検証する。
+print("\n[TEST 9] 再戦（同一ルームで2ゲーム目）")
+
+room_ref.update({"category": "PARTY"})  # 1ゲーム目のカテゴリを明示しておく
+
+room_before_restart = room_ref.get()
+prev_game_count = (room_before_restart.to_dict() or {}).get("gameCount") or 1
+check("再戦前 gameCount は未設定なら1扱い", prev_game_count == 1, f"実際={prev_game_count}")
+
+room_ref.update({
+    "status": "WAITING",
+    "currentRound": 0,
+    "gameCount": prev_game_count + 1,
+    "currentQuestion": None,
+    "answerCounts": {},
+    "roundScores": [],
+    "finalScores": [],
+    "cumulativeTotals": {},
+})
+snap = room_ref.get()
+check("status=WAITING に戻る", snap.get("status") == "WAITING")
+check("gameCount=2 にインクリメントされる", snap.get("gameCount") == 2)
+check("cumulativeTotals が空（前ゲームのスコアを持ち越さない）", snap.get("cumulativeTotals") == {})
+check("category が引き継がれる（PARTY のまま）", snap.get("category") == "PARTY")
+
+# 2ゲーム目開始（gameCount=2）。round=1 は1ゲーム目と同じ番号だが、
+# roundId に gameCount を含めることで rounds/1_1 とは別ドキュメントになる。
+game_count = snap.get("gameCount")
+round_ref_g2 = room_ref.collection("rounds").document(f"{game_count}_1")
+room_ref.update({
+    "status": "ANSWERING",
+    "currentRound": 1,
+    "currentQuestion": question,
+    "startedAt": datetime.now(timezone.utc),
+})
+
+for pid, answer in answers_input:
+    round_ref_g2.collection("answers").document(pid).set({
+        "answer": answer,
+        "answeredAt": datetime.now(timezone.utc),
+    })
+
+g2_answers_snap = round_ref_g2.collection("answers").get()
+check("2ゲーム目 round=1 に全員分の回答が書き込める（衝突なし）",
+      len(g2_answers_snap) == len(players), f"{len(g2_answers_snap)}/{len(players)}人")
+
+g1_answers_snap = room_ref.collection("rounds").document("1").collection("answers").get()
+check("1ゲーム目 rounds/1/answers は削除されず残っている（roundIdが別なので独立）",
+      len(g1_answers_snap) == len(players), f"{len(g1_answers_snap)}人")
+
 # ── クリーンアップ ─────────────────────────────────────────────
 print("\n[CLEANUP] テストデータ削除...")
-for col in ["1", "2"]:
+for col in ["1", "2", "2_1"]:
     ans_docs = room_ref.collection("rounds").document(col).collection("answers").get()
     for d in ans_docs:
         d.reference.delete()

--- a/backend/test_logic.py
+++ b/backend/test_logic.py
@@ -214,6 +214,85 @@ r_perfect_preds = [("X", "はい", 3)]
 totals_5 = simulate_rounds([(r_perfect_counts, r_perfect_preds)] * 5)
 check("5ラウンド満点: 500点", totals_5["X"] == 500, f"実際={totals_5['X']}")
 
+# ── TEST 9: 再戦（restartGame, Issue #17）───────────────────
+print("\n[TEST 9] 再戦ロジック")
+
+
+def round_doc_id(game_count: int, round_num: int) -> str:
+    """FirebaseRepository.roundDocId() / index.html roundDocId() と同じ形式。"""
+    return f"{game_count}_{round_num}"
+
+
+check("1ゲーム目 round=1 のID", round_doc_id(1, 1) == "1_1")
+check("2ゲーム目（再戦後）round=1 のID", round_doc_id(2, 1) == "2_1")
+check("gameCountが違えば同じroundでも別ID",
+      round_doc_id(1, 3) != round_doc_id(2, 3),
+      f"{round_doc_id(1, 3)} vs {round_doc_id(2, 3)}")
+
+
+def pick_first_question(question_queue: list[dict], avoid_question_id: str | None) -> list[dict]:
+    """
+    startGame() の「前ゲーム最後の質問を1問目にしない」ロジックの純粋関数版。
+    Kotlin(FirebaseRepository.startGame) / JS(index.html startGame) と同じ優先順位:
+      1. queue内に別の質問があれば先頭と入れ替え
+      2. queue内が全部同じ質問なら諦める（呼び出し側でプール全体から探す運用は別途）
+    """
+    if not avoid_question_id or not question_queue:
+        return question_queue
+    if question_queue[0]["questionId"] != avoid_question_id:
+        return question_queue
+    alt_index = next(
+        (i for i, q in enumerate(question_queue) if q["questionId"] != avoid_question_id),
+        -1,
+    )
+    if alt_index > 0:
+        swapped = question_queue[:]
+        swapped[0], swapped[alt_index] = swapped[alt_index], swapped[0]
+        return swapped
+    return question_queue  # 代替なし
+
+
+queue_a = [{"questionId": "f001"}, {"questionId": "f002"}, {"questionId": "f003"}]
+result_a = pick_first_question(queue_a, "f001")
+check("前ゲーム最後の質問が1問目なら入れ替える", result_a[0]["questionId"] != "f001",
+      f"1問目={result_a[0]['questionId']}")
+
+queue_b = [{"questionId": "f002"}, {"questionId": "f001"}, {"questionId": "f003"}]
+result_b = pick_first_question(queue_b, "f001")
+check("1問目が対象外ならそのまま", result_b == queue_b)
+
+queue_c = [{"questionId": "f001"}]
+result_c = pick_first_question(queue_c, "f001")
+check("キューが1問だけ（全部同じ）なら諦めてそのまま返す", result_c == queue_c)
+
+check("avoid_question_id が None なら何もしない", pick_first_question(queue_a, None) == queue_a)
+
+# ── TEST 10: 再戦時のスコアリセット ──────────────────────────
+print("\n[TEST 10] 再戦時のスコアリセット")
+
+
+def restart_room_fields(prev_game_count: int) -> dict:
+    """restartGame() が上書きするフィールドの純粋関数版（category は含めない＝引き継ぐ）。"""
+    return {
+        "status": "WAITING",
+        "currentRound": 0,
+        "gameCount": prev_game_count + 1,
+        "currentQuestion": None,
+        "answerCounts": {},
+        "roundScores": [],
+        "finalScores": [],
+        "cumulativeTotals": {},
+    }
+
+
+restarted = restart_room_fields(prev_game_count=1)
+check("status が WAITING に戻る", restarted["status"] == "WAITING")
+check("currentRound が 0 にリセットされる", restarted["currentRound"] == 0)
+check("gameCount がインクリメントされる", restarted["gameCount"] == 2)
+check("cumulativeTotals が空になる（前ゲームのスコアを持ち越さない）",
+      restarted["cumulativeTotals"] == {})
+check("category キーは含まれない（＝引き継ぎ、上書きしない）", "category" not in restarted)
+
 # ─── 結果サマリー ─────────────────────────────────────────────
 print("\n" + "=" * 55)
 if errors:

--- a/backend/web/index.html
+++ b/backend/web/index.html
@@ -170,7 +170,8 @@
     <div class="score-card">
       <div id="final-scores"></div>
     </div>
-    <button class="btn-primary" onclick="resetGame()" style="margin-top:16px">トップに戻る</button>
+    <button class="btn-primary" id="restart-btn" onclick="restartGame()" style="margin-top:16px;display:none">もう一度遊ぶ</button>
+    <button class="btn-secondary" onclick="resetGame()" style="margin-top:8px">トップに戻る</button>
   </div>
 </div>
 
@@ -179,7 +180,7 @@
   import { getAuth, signInAnonymously } from 'https://www.gstatic.com/firebasejs/10.12.0/firebase-auth.js';
   import {
     getFirestore, doc, collection, setDoc, updateDoc, getDoc, getDocs,
-    onSnapshot, serverTimestamp, increment
+    onSnapshot, serverTimestamp, increment, deleteField
   } from 'https://www.gstatic.com/firebasejs/10.12.0/firebase-firestore.js';
 
   const app = initializeApp({
@@ -229,6 +230,7 @@
   window.submitAnswer = submitAnswer;
   window.submitPrediction = submitPrediction;
   window.resetGame = resetGame;
+  window.restartGame = restartGame;
 
   function showScreen(name) {
     document.querySelectorAll('.screen').forEach(s => s.classList.remove('active'));
@@ -267,6 +269,9 @@
       hostName, hostUid: state.uid,
       status: 'WAITING', currentRound: 0, totalRounds: 5,
       currentQuestion: null, category, createdAt: serverTimestamp(),
+      // 再戦（restartGame）ごとにインクリメントする世代番号。
+      // rounds/{gameCount}_{round} のドキュメントIDに使い、前ゲームの回答と衝突させない（Issue #17）。
+      gameCount: 1,
     });
     await setDoc(doc(db, 'rooms', roomId, 'players', state.uid), {
       nickname: hostName, isHost: true, joinedAt: serverTimestamp(),
@@ -354,6 +359,14 @@
         }
       } else if (phase === 'FINISHED') {
         renderFinished(data);
+      } else if (phase === 'WAITING') {
+        // ホストの「もう一度遊ぶ」（restartGame）で FINISHED → WAITING に戻った場合、
+        // ルームID再入力・QR再スキャンなしで全員を自動的に待合室へ戻す（Issue #17）。
+        clearTimeout(state.autoAdvanceTimer);
+        document.getElementById('display-room-id').textContent = state.roomId;
+        document.getElementById('host-controls').style.display = state.isHost ? 'block' : 'none';
+        document.getElementById('guest-waiting-msg').style.display = state.isHost ? 'none' : 'block';
+        showScreen('waiting');
       }
     });
   }
@@ -426,6 +439,13 @@
     return a;
   }
 
+  // rounds サブコレクションのドキュメントID。gameCount を含めることで、restartGame() 後の
+  // 2ゲーム目が前ゲームの rounds/{round}/answers と衝突しないようにする（Issue #17）。
+  // Android（FirebaseRepository.roundDocId）と同じ形式にすること。
+  function roundDocId(gameCount, round) {
+    return `${gameCount || 1}_${round}`;
+  }
+
   async function startGame() {
     const roomRef = doc(db, 'rooms', state.roomId);
     const roomSnap = await getDoc(roomRef);
@@ -433,13 +453,28 @@
     const tags = categoryTags(roomData.category);
     const filtered = ALL_QUESTIONS.filter(q => q.tags.some(t => tags.includes(t)));
     const pool = filtered.length > 0 ? filtered : ALL_QUESTIONS;
-    const questionQueue = shuffleArray(pool).slice(0, TOTAL_ROUNDS_PER_GAME);
+    let questionQueue = shuffleArray(pool).slice(0, TOTAL_ROUNDS_PER_GAME);
+
+    // 再戦時、前ゲーム最後の質問がそのまま1問目にならないよう、可能なら入れ替える（Issue #17）。
+    const avoidQuestionId = roomData.lastPlayedQuestionId;
+    if (avoidQuestionId && questionQueue[0] && questionQueue[0].questionId === avoidQuestionId) {
+      const altIndex = questionQueue.findIndex(q => q.questionId !== avoidQuestionId);
+      if (altIndex > 0) {
+        [questionQueue[0], questionQueue[altIndex]] = [questionQueue[altIndex], questionQueue[0]];
+      } else {
+        const usedIds = new Set(questionQueue.map(q => q.questionId));
+        const replacement = pool.find(q => q.questionId !== avoidQuestionId && !usedIds.has(q.questionId));
+        if (replacement) questionQueue = [replacement, ...questionQueue.slice(1)];
+      }
+    }
+
     await updateDoc(roomRef, {
       status: 'ANSWERING', currentRound: 1,
       totalRounds: questionQueue.length,
       questionQueue: questionQueue,
       currentQuestion: questionQueue[0], startedAt: serverTimestamp(),
       phaseStartedAt: serverTimestamp(),
+      lastPlayedQuestionId: deleteField(),
     });
   }
 
@@ -469,15 +504,16 @@
     const roomRef = doc(db, 'rooms', state.roomId);
     const roomData = (await getDoc(roomRef)).data();
     const currentRound = roomData.currentRound;
-    const roundRef = doc(db, 'rooms', state.roomId, 'rounds', String(currentRound));
-    const answerRef = doc(db, 'rooms', state.roomId, 'rounds', String(currentRound), 'answers', state.uid);
+    const roundId = roundDocId(roomData.gameCount, currentRound);
+    const roundRef = doc(db, 'rooms', state.roomId, 'rounds', roundId);
+    const answerRef = doc(db, 'rooms', state.roomId, 'rounds', roundId, 'answers', state.uid);
 
     await setDoc(answerRef, { answer, answeredAt: serverTimestamp() });
 
     // 全員回答したか確認
     const [players, answers] = await Promise.all([
       getDocs(collection(db, 'rooms', state.roomId, 'players')),
-      getDocs(collection(db, 'rooms', state.roomId, 'rounds', String(currentRound), 'answers')),
+      getDocs(collection(db, 'rooms', state.roomId, 'rounds', roundId, 'answers')),
     ]);
 
     if (answers.size >= players.size) {
@@ -509,7 +545,8 @@
     if (roomData.status !== 'ANSWERING') return; // すでに遷移済み
 
     const currentRound = roomData.currentRound;
-    const answers = await getDocs(collection(db, 'rooms', state.roomId, 'rounds', String(currentRound), 'answers'));
+    const roundId = roundDocId(roomData.gameCount, currentRound);
+    const answers = await getDocs(collection(db, 'rooms', state.roomId, 'rounds', roundId, 'answers'));
     await advanceToPredicting(roomRef, roomData, answers.docs);
   }
 
@@ -543,14 +580,15 @@
     const roomRef = doc(db, 'rooms', state.roomId);
     const roomData = (await getDoc(roomRef)).data();
     const currentRound = roomData.currentRound;
-    const answerRef = doc(db, 'rooms', state.roomId, 'rounds', String(currentRound), 'answers', state.uid);
+    const roundId = roundDocId(roomData.gameCount, currentRound);
+    const answerRef = doc(db, 'rooms', state.roomId, 'rounds', roundId, 'answers', state.uid);
 
     await updateDoc(answerRef, { prediction: predictedCount, targetOption, predictedAt: serverTimestamp() });
 
     // 全員予測したか確認
     const [players, answers] = await Promise.all([
       getDocs(collection(db, 'rooms', state.roomId, 'players')),
-      getDocs(collection(db, 'rooms', state.roomId, 'rounds', String(currentRound), 'answers')),
+      getDocs(collection(db, 'rooms', state.roomId, 'rounds', roundId, 'answers')),
     ]);
 
     const predicted = answers.docs.filter(d => d.data().prediction !== undefined);
@@ -570,7 +608,8 @@
     if (roomData.status !== 'PREDICTING') return; // すでに確定済み
 
     const currentRound = roomData.currentRound;
-    const answers = await getDocs(collection(db, 'rooms', state.roomId, 'rounds', String(currentRound), 'answers'));
+    const roundId = roundDocId(roomData.gameCount, currentRound);
+    const answers = await getDocs(collection(db, 'rooms', state.roomId, 'rounds', roundId, 'answers'));
     await finalizeRound(roomRef, roomData, currentRound, answers.docs);
   }
 
@@ -715,7 +754,40 @@
         <span class="score-pts">${s.roundScore}点</span>
       </div>`;
     }).join('');
+    // 「もう一度遊ぶ」はホストにのみ表示（Android の FinishedScreen と同様）。
+    document.getElementById('restart-btn').style.display = state.isHost ? 'block' : 'none';
     showScreen('finished');
+  }
+
+  // ── 再戦（同一ルームを再利用してもう一度遊ぶ、ホストのみ） ──
+  // status を WAITING に戻す。observeRoom（onSnapshot）がその遷移を検知し、
+  // 参加者側の画面も含めて自動で待機室へ戻す。category は引き継ぐ。
+  // gameCount をインクリメントし、rounds/{gameCount}_{round} のドキュメントIDを次ゲームで
+  // 変えることで、submitAnswer() の「すでに回答済みです」を防ぐ（Issue #17）。
+  async function restartGame() {
+    const roomRef = doc(db, 'rooms', state.roomId);
+    const roomSnap = await getDoc(roomRef);
+    if (!roomSnap.exists()) return;
+    const roomData = roomSnap.data();
+    if (roomData.status !== 'FINISHED') return;
+
+    const prevGameCount = roomData.gameCount || 1;
+    const lastQuestionId = roomData.currentQuestion ? roomData.currentQuestion.questionId : null;
+
+    await updateDoc(roomRef, {
+      status: 'WAITING',
+      currentRound: 0,
+      gameCount: prevGameCount + 1,
+      questionQueue: deleteField(),
+      currentQuestion: null,
+      answerCounts: {},
+      roundScores: [],
+      finalScores: [],
+      cumulativeTotals: {},
+      nextRound: deleteField(),
+      restartedAt: serverTimestamp(),
+      lastPlayedQuestionId: lastQuestionId || deleteField(),
+    });
   }
 
   function resetGame() {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,9 +79,12 @@ flowchart TB
 | `cumulativeTotals` | map | ラウンド確定時 / 終了時 | プレイヤーごとの累計得点 |
 | `nextRound` | number | ラウンド確定時 | 次に進むラウンド番号 |
 | `phaseStartedAt` | timestamp | フェーズ遷移時 | **現フェーズの開始サーバー時刻。タイムアウト判定の基準**（Issue #14） |
+| `gameCount` | number | createRoom / restartGame | **再戦のたびにインクリメントする世代番号（既定1）。`rounds/{gameCount}_{round}` のドキュメントIDに使い、再戦後の2ゲーム目が前ゲームの回答と衝突しないようにする**（Issue #17） |
+| `lastPlayedQuestionId` | string | restartGame（設定）/ startGame（削除） | 前ゲーム最終問題のID。再戦直後の1問目に同じ質問が連続しないよう startGame() が参照する一時フィールド |
 | `createdAt` | timestamp | createRoom | ルーム作成時刻 |
 | `startedAt` | timestamp | startGame | ゲーム開始時刻 |
 | `finishedAt` | timestamp | ゲーム終了時 | ゲーム終了時刻 |
+| `restartedAt` | timestamp | restartGame | 再戦を開始した時刻 |
 
 `PlayerScore` の構造: `{ playerId, nickname, targetOption, predictedCount, actualCount, roundScore, totalScore }`
 
@@ -93,7 +96,12 @@ flowchart TB
 | `isHost` | boolean | ホストかどうか |
 | `joinedAt` | timestamp | 入室時刻 |
 
-### `rooms/{roomId}/rounds/{round}/answers/{uid}`
+### `rooms/{roomId}/rounds/{gameCount}_{round}/answers/{uid}`
+
+> ドキュメントID（`{round}` のみだった旧仕様から `{gameCount}_{round}` に変更。Issue #17）。
+> `restartGame()` は `gameCount` をインクリメントするだけで前ゲームの `rounds` ドキュメントは削除しない
+> （履歴として残る）。そのため2ゲーム目の `round=1` が前ゲームの `round=1` と衝突せず、
+> `submitAnswer()` の「すでに回答済みです」判定が誤爆しない。
 
 | フィールド | 型 | 説明 |
 |---|---|---|
@@ -140,11 +148,18 @@ PREDICTING（予測フェーズ：既定 predictSeconds = 20秒）
 RESULT（結果表示：10秒）
   ↓ 次のラウンドへ or ゲーム終了
 FINISHED（最終結果）
+  ↓ ホストが「もう一度遊ぶ」（restartGame）
+WAITING（同一ルームで再戦）
 ```
 
 - 状態変更は Firestore ドキュメントの更新で行い、各クライアントは `addSnapshotListener` で自動検知して UI を更新する
 - **タイムアウトはホスト端末が主導して確定させる**（Issue #14）。基準時刻は端末のローカル時計ではなく `phaseStartedAt`（サーバー時刻）から算出するため、途中参加・画面復帰した端末でもズレない
 - 未提出者は当該ラウンドのスコア集計から除外される
+- **`FINISHED → WAITING` はホストの「もう一度遊ぶ」でのみ発生する**（Issue #17）。`restartGame()` は
+  `category` を引き継いだまま `status/currentRound/スコア類` をリセットし、`gameCount` をインクリメントする。
+  参加者側は `observeRoom` でこの遷移を検知し、ルームID再入力・QR再スキャンなしで自動的に待合室へ戻る。
+  再戦時も新規参加は引き続き受け付ける（途中参加が自然なパーティー用途のため、意図的な仕様）。
+  「トップに戻る」（`resetGame`）はルームから離脱してホーム画面に戻るだけで、`FINISHED → WAITING` は起こさない
 
 > ⚠️ ホスト自身が離脱するとタイムアウト確定を実行する主体がいなくなる。この扱いは Issue #15 で対応する（Firestore ハートビートで検知し、ルームを終了する方針で確定済み）。
 
@@ -188,7 +203,7 @@ python3 scripts/generate_questions.py --check # 同期検証のみ（CI で実�
 |---|---|---|---|---|
 | `rooms/{roomId}` | 認証済み | `hostUid == 自分` | 参加者 | ホスト |
 | `players/{uid}` | 参加者 | 自分のみ | 自分のみ | 自分 or ホスト |
-| `rounds/{n}/answers/{uid}` | 参加者 | 参加者かつ自分 | 参加者※ | ホスト |
+| `rounds/{roundId}/answers/{uid}`（`roundId` = `{gameCount}_{round}`） | 参加者 | 参加者かつ自分 | 参加者※ | ホスト |
 
 ルーム本体の read だけ認証済みに開放しているのは、`joinRoom()` が入室前に存在確認・満員判定でルームを読む必要があるため。
 


### PR DESCRIPTION
Closes #17

## 概要

終了画面の「もう一度遊ぶ」が「トップに戻る」と完全に同一処理（`vm.resetGame()` → HOME 遷移）になっていた問題を修正し、同一ルームを再利用した再戦を実装する（Issue #17 / US-009）。

## 変更内容

### Android
- `FirebaseRepository.restartGame(roomId)` を追加。`status` を `WAITING` に戻し、`currentRound`・`questionQueue`・`currentQuestion`・`answerCounts`・`roundScores`・`finalScores`・`cumulativeTotals`・`nextRound` をリセットしつつ `category` は引き継ぐ
- `gameCount` フィールドを新設（`createRoom` で初期値1、`restartGame` でインクリメント）。`rounds` サブコレクションのドキュメントIDを `{gameCount}_{round}` に変更し、2ゲーム目の `round=1` が1ゲーム目の `round=1` と衝突しないようにした（前ゲームの回答は削除せず履歴として残す）
- `startGame()` は再戦直後、前ゲーム最終問題（`lastPlayedQuestionId`）が新しい1問目にならないよう、可能なら入れ替える
- `GameViewModel.restartGame()` を追加（`resetGame()` と異なり roomId/observer を維持）
- `MainActivity`/`FinishedScreen`: `onRestart`（再戦）と `onHome`（トップに戻る）を明確に分離。`onRestart` は `restartGame()` を呼ぶのみで、実際の画面遷移は `observeRoom` が検知した `FINISHED → WAITING` を `FinishedScreen` の `LaunchedEffect` が検知して行う（ホストは QR表示/開始画面へ、参加者は待合室へ）。これにより参加者側のルームID再入力・QR再スキャンは不要

### Web クライアント（backend/web/index.html）
- Android と同じ `gameCount` / `roundId` 体系・`restartGame()` を実装
- 終了画面にホストのみ表示される「もう一度遊ぶ」ボタンを追加
- `onSnapshot` に `FINISHED → WAITING` 遷移を検知して待合室へ戻すブランチを追加

### ドキュメント
- `docs/architecture.md`: `gameCount`/`lastPlayedQuestionId`フィールド、`rounds/{gameCount}_{round}` の命名規則、`FINISHED → WAITING` の状態遷移を追記
- `README.md`: 状態遷移図とスキーマ例を更新

### 対象外にしたもの
- `backend/functions/main.py`（Cloud Functions）は変更していません。`docs/architecture.md` に明記されている通り「現役のAPIではない」レガシー実装で、クライアントは Firestore を直接読み書きしているため、Issue本文が挙げた対象ファイルにも含まれていません

## テスト

実機/エミュレータでの手動確認ができない実行環境のため、以下の自動テストで代替しました（**限界: 実際のUI操作感・複数端末間のタイミングずれは検証していません**）。

- `backend/test_logic.py`（純粋関数テスト、Firestore不要）
  - `roundDocId` 生成ロジック、質問再抽選の回避ロジック、再戦時のフィールドリセットを検証
  - 実行: `python3 backend/test_logic.py` → 全件合格
- `backend/test_game_flow.py`（Firestore Emulator, firebase-admin SDK）
  - 1ゲーム目終了 → 再戦 → 2ゲーム目 round=1 で回答衝突が起きないこと、`cumulativeTotals` がリセットされること、`category` が引き継がれることを確認
  - 実行: `FIRESTORE_EMULATOR_HOST=localhost:8080 python3 backend/test_game_flow.py` → 全件合格
- `backend/rules-tests/gameflow.test.mjs`（Firestore Emulator, クライアントSDK・firestore.rules適用下）
  - 既存の1ゲーム目フローのroundIdを新形式（`1_1`）に更新した上で、ホストが再戦できること・新しいroundId（`2_1`）に書き込めること・前ゲームのroundデータが独立して残ることを追加検証
  - 実行: `firebase emulators:exec --project hitokazu-game-rules-test --only firestore "npm --prefix rules-tests test"` → 34件全件合格（既存32件＋新規2件）
- `backend/test_questions_sync.py` も回帰確認のため実行し、全件合格（質問マスタ同期には影響なし）
- Android側は `./gradlew compileDebugKotlin` でコンパイルエラーがないことを確認（このリポジトリには元々JVM単体テストの仕組みがないため、新規追加はしていません）

## 受け入れ基準チェック

- [x] ホストが終了画面で「もう一度遊ぶ」を押すと、参加者全員の画面が自動で待合室に遷移し、ルームIDの再入力・QR再スキャンが不要である（`observeRoom` の `FINISHED → WAITING` 検知で実装、rules-tests で疎通確認）
- [x] 再戦したゲームのスコアが0から始まる（`cumulativeTotals` を空にリセット。test_game_flow.py で確認）
- [x] 2ゲーム目でも `submitAnswer()` が「すでに回答済みです」エラーにならない（`gameCount` によるroundId分離。test_game_flow.py / gameflow.test.mjs で確認）
- [x] 「トップに戻る」を押した場合は従来どおりホーム画面に戻り、「もう一度遊ぶ」と挙動が区別されている（`onHome`/`onRestart` を分離）
- [x] Webクライアントが `FINISHED → WAITING` の遷移でエラーにならない（`onSnapshot` に専用分岐を追加）
- [x] US-009の受け入れ条件について、上記自動テストで検証した記録を本PRに残した（実機2ゲーム連続プレイの手動確認は環境上未実施）

## 並行実装に関する注意

直前に同じリポジトリで Issue #15（ホスト離脱時のルーム終了処理）が実装され、PR #30（ブランチ `feature/issue-15-host-heartbeat`）が作成されていますが、まだマージされていません。本PRは PR #30 のマージを待たず、現在の main をベースに実装しています。

`FirebaseRepository.kt` / `GameViewModel.kt` / `MainActivity.kt` / `backend/web/index.html` は両PRが触れているため、**マージ時にコンフリクト解消が必要になる可能性があります**。特に `FirebaseRepository.kt` の `restartGame()`/`roundDocId()` 追加箇所と、PR #30 のハートビート関連の変更が近い位置に入る可能性があるため、レビュー・マージ時にご確認ください。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
