### PR TITLE
fix: 接続断の監視とConnectionBanner/reconnect()を実装

### DIFF
--- a/android/app/src/main/java/com/rokusoudo/hitokazu/data/firebase/FirebaseRepository.kt
+++ b/android/app/src/main/java/com/rokusoudo/hitokazu/data/firebase/FirebaseRepository.kt
@@ -1,7 +1,9 @@
 package com.rokusoudo.hitokazu.data.firebase
 
+import android.util.Log
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.firestore.FieldValue
+import com.google.firebase.firestore.MetadataChanges
 import com.google.firebase.firestore.SetOptions
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
@@ -11,6 +13,21 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.tasks.await
+
+private const val TAG = "FirebaseRepository"
+
+// ── リアルタイム監視の通知イベント ──────────────────────
+// addSnapshotListenerのerrorをUI側へ伝えるため、データ更新とエラーを
+// 区別できるsealed classとして公開する（Issue #18: errorをもみ消さない）。
+sealed class RoomEvent {
+    data class Data(val snapshot: RoomSnapshot, val isFromCache: Boolean) : RoomEvent()
+    data class Error(val throwable: Throwable) : RoomEvent()
+}
+
+sealed class PlayersEvent {
+    data class Data(val players: List<Player>, val isFromCache: Boolean) : PlayersEvent()
+    data class Error(val throwable: Throwable) : PlayersEvent()
+}
 
 class FirebaseRepository {
 
@@ -332,22 +349,38 @@ class FirebaseRepository {
     }
 
     // ── ルーム状態をリアルタイム監視（Firestoreリスナー） ──
-    fun observeRoom(roomId: String): Flow<RoomSnapshot> = callbackFlow {
+    // snapshot.metadata.isFromCache をUI側（GameViewModel）に伝えることで、
+    // サーバー由来の更新が一定時間来ない状態＝切断とみなす判定を可能にする。
+    // MetadataChanges.INCLUDE を付けないと、データ自体に変化がないメタデータのみの
+    // 遷移（オンライン↔オフライン）ではコールバックが一切呼ばれず、切断検知ができない。
+    // error はもみ消さず、Logcatへの出力とRoomEvent.Errorとしての通知の両方を行う（Issue #18）。
+    fun observeRoom(roomId: String): Flow<RoomEvent> = callbackFlow {
         val listener = db.collection("rooms").document(roomId)
-            .addSnapshotListener { snapshot, error ->
-                if (error != null || snapshot == null) return@addSnapshotListener
+            .addSnapshotListener(MetadataChanges.INCLUDE) { snapshot, error ->
+                if (error != null) {
+                    Log.e(TAG, "observeRoom snapshot error (roomId=$roomId)", error)
+                    trySend(RoomEvent.Error(error))
+                    return@addSnapshotListener
+                }
+                if (snapshot == null) return@addSnapshotListener
                 val data = snapshot.data ?: return@addSnapshotListener
-                trySend(RoomSnapshot.fromMap(data))
+                trySend(RoomEvent.Data(RoomSnapshot.fromMap(data), snapshot.metadata.isFromCache))
             }
         awaitClose { listener.remove() }
     }
 
     // ── プレイヤー一覧をリアルタイム監視 ───────────────────
-    fun observePlayers(roomId: String): Flow<List<Player>> = callbackFlow {
+    // observeRoomと同様、MetadataChanges.INCLUDEでキャッシュ⇔サーバーの遷移を検知する。
+    fun observePlayers(roomId: String): Flow<PlayersEvent> = callbackFlow {
         val listener = db.collection("rooms").document(roomId)
             .collection("players")
-            .addSnapshotListener { snapshot, error ->
-                if (error != null || snapshot == null) return@addSnapshotListener
+            .addSnapshotListener(MetadataChanges.INCLUDE) { snapshot, error ->
+                if (error != null) {
+                    Log.e(TAG, "observePlayers snapshot error (roomId=$roomId)", error)
+                    trySend(PlayersEvent.Error(error))
+                    return@addSnapshotListener
+                }
+                if (snapshot == null) return@addSnapshotListener
                 val players = snapshot.documents.map { doc ->
                     Player(
                         playerId = doc.id,
@@ -355,9 +388,16 @@ class FirebaseRepository {
                         isHost = doc.getBoolean("isHost") ?: false,
                     )
                 }
-                trySend(players)
+                trySend(PlayersEvent.Data(players, snapshot.metadata.isFromCache))
             }
         awaitClose { listener.remove() }
+    }
+
+    // ── ネットワーク再接続（再接続ボタンから呼び出す） ─────
+    // リスナーの張り直し（GameViewModel.reconnect）と併用し、切断状態からの
+    // 復帰を早める。すでに有効化されている場合は何もしない安全な操作。
+    suspend fun enableNetwork(): Result<Unit> = runCatching {
+        db.enableNetwork().await()
     }
 }
 

--- a/android/app/src/main/java/com/rokusoudo/hitokazu/ui/screens/AnsweringScreen.kt
+++ b/android/app/src/main/java/com/rokusoudo/hitokazu/ui/screens/AnsweringScreen.kt
@@ -29,7 +29,7 @@ fun AnsweringScreen(
 
     Column(modifier = Modifier.fillMaxSize()) {
         ConnectionBanner(
-            isDisconnected = false,
+            isDisconnected = uiState.isDisconnected,
             onReconnect = { viewModel.reconnect() },
         )
 

--- a/android/app/src/main/java/com/rokusoudo/hitokazu/ui/screens/FinishedScreen.kt
+++ b/android/app/src/main/java/com/rokusoudo/hitokazu/ui/screens/FinishedScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.rokusoudo.hitokazu.data.model.PlayerScore
+import com.rokusoudo.hitokazu.ui.components.ConnectionBanner
 import com.rokusoudo.hitokazu.viewmodel.GameViewModel
 
 @Composable
@@ -25,96 +26,103 @@ fun FinishedScreen(
     val uiState by viewModel.uiState.collectAsState()
     val winner = uiState.scores.firstOrNull()
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(24.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        Spacer(modifier = Modifier.height(16.dp))
-
-        Text(
-            text = "ゲーム終了！",
-            fontSize = 32.sp,
-            fontWeight = FontWeight.Bold,
+    Column(modifier = Modifier.fillMaxSize()) {
+        ConnectionBanner(
+            isDisconnected = uiState.isDisconnected,
+            onReconnect = { viewModel.reconnect() },
         )
 
-        Text(
-            text = "お疲れさまでした",
-            fontSize = 16.sp,
-            color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
-            modifier = Modifier.padding(top = 4.dp, bottom = 24.dp),
-        )
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Spacer(modifier = Modifier.height(16.dp))
 
-        // 優勝者
-        winner?.let {
-            Card(
-                modifier = Modifier.fillMaxWidth(),
-                colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.primaryContainer,
-                ),
-            ) {
-                Column(
-                    modifier = Modifier.padding(24.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally,
+            Text(
+                text = "ゲーム終了！",
+                fontSize = 32.sp,
+                fontWeight = FontWeight.Bold,
+            )
+
+            Text(
+                text = "お疲れさまでした",
+                fontSize = 16.sp,
+                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+                modifier = Modifier.padding(top = 4.dp, bottom = 24.dp),
+            )
+
+            // 優勝者
+            winner?.let {
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    ),
                 ) {
-                    Text(text = "🏆 優勝", fontSize = 18.sp)
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Text(
-                        text = it.nickname.ifEmpty { it.playerId } + if (it.playerId == uiState.playerId) "（あなた！）" else "",
-                        fontSize = 22.sp,
-                        fontWeight = FontWeight.Bold,
-                        textAlign = TextAlign.Center,
-                    )
-                    Text(
-                        text = "${it.totalScore}点",
-                        fontSize = 28.sp,
-                        fontWeight = FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.primary,
-                    )
+                    Column(
+                        modifier = Modifier.padding(24.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        Text(text = "🏆 優勝", fontSize = 18.sp)
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            text = it.nickname.ifEmpty { it.playerId } + if (it.playerId == uiState.playerId) "（あなた！）" else "",
+                            fontSize = 22.sp,
+                            fontWeight = FontWeight.Bold,
+                            textAlign = TextAlign.Center,
+                        )
+                        Text(
+                            text = "${it.totalScore}点",
+                            fontSize = 28.sp,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                    }
                 }
             }
-        }
 
-        Spacer(modifier = Modifier.height(24.dp))
+            Spacer(modifier = Modifier.height(24.dp))
 
-        Text(
-            text = "最終ランキング",
-            fontSize = 18.sp,
-            fontWeight = FontWeight.Bold,
-        )
+            Text(
+                text = "最終ランキング",
+                fontSize = 18.sp,
+                fontWeight = FontWeight.Bold,
+            )
 
-        Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(8.dp))
 
-        LazyColumn(
-            modifier = Modifier.weight(1f),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            itemsIndexed(uiState.scores) { index, score ->
-                FinalRankingRow(rank = index + 1, score = score, myPlayerId = uiState.playerId)
+            LazyColumn(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                itemsIndexed(uiState.scores) { index, score ->
+                    FinalRankingRow(rank = index + 1, score = score, myPlayerId = uiState.playerId)
+                }
             }
-        }
 
-        Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(16.dp))
 
-        if (uiState.isHost) {
-            Button(
-                onClick = onRestart,
+            if (uiState.isHost) {
+                Button(
+                    onClick = onRestart,
+                    modifier = Modifier.fillMaxWidth().height(52.dp),
+                ) {
+                    Text("もう一度遊ぶ", fontSize = 16.sp)
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+
+            OutlinedButton(
+                onClick = onHome,
                 modifier = Modifier.fillMaxWidth().height(52.dp),
             ) {
-                Text("もう一度遊ぶ", fontSize = 16.sp)
+                Text("トップに戻る", fontSize = 16.sp)
             }
-            Spacer(modifier = Modifier.height(8.dp))
-        }
 
-        OutlinedButton(
-            onClick = onHome,
-            modifier = Modifier.fillMaxWidth().height(52.dp),
-        ) {
-            Text("トップに戻る", fontSize = 16.sp)
+            Spacer(modifier = Modifier.height(16.dp))
         }
-
-        Spacer(modifier = Modifier.height(16.dp))
     }
 }
 

--- a/android/app/src/main/java/com/rokusoudo/hitokazu/ui/screens/PredictingScreen.kt
+++ b/android/app/src/main/java/com/rokusoudo/hitokazu/ui/screens/PredictingScreen.kt
@@ -35,7 +35,7 @@ fun PredictingScreen(
 
     Column(modifier = Modifier.fillMaxSize()) {
         ConnectionBanner(
-            isDisconnected = false,
+            isDisconnected = uiState.isDisconnected,
             onReconnect = { viewModel.reconnect() },
         )
 

--- a/android/app/src/main/java/com/rokusoudo/hitokazu/ui/screens/ResultScreen.kt
+++ b/android/app/src/main/java/com/rokusoudo/hitokazu/ui/screens/ResultScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.rokusoudo.hitokazu.data.model.GamePhase
 import com.rokusoudo.hitokazu.data.model.PlayerScore
+import com.rokusoudo.hitokazu.ui.components.ConnectionBanner
 import com.rokusoudo.hitokazu.viewmodel.GameViewModel
 
 @Composable
@@ -35,116 +36,123 @@ fun ResultScreen(
     val counts = uiState.answerCounts
     val myScore = uiState.scores.find { it.playerId == uiState.playerId }
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(24.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        Text(
-            text = "第${uiState.currentRound}問 結果",
-            fontSize = 22.sp,
-            fontWeight = FontWeight.Bold,
+    Column(modifier = Modifier.fillMaxSize()) {
+        ConnectionBanner(
+            isDisconnected = uiState.isDisconnected,
+            onReconnect = { viewModel.reconnect() },
         )
 
-        Spacer(modifier = Modifier.height(16.dp))
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = "第${uiState.currentRound}問 結果",
+                fontSize = 22.sp,
+                fontWeight = FontWeight.Bold,
+            )
 
-        // 実際の回答集計
-        question?.let { q ->
-            Card(
-                modifier = Modifier.fillMaxWidth(),
-                colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                ),
-            ) {
-                Column(modifier = Modifier.padding(16.dp)) {
-                    Text(
-                        text = q.text,
-                        fontSize = 16.sp,
-                        fontWeight = FontWeight.Medium,
-                        textAlign = TextAlign.Center,
-                        modifier = Modifier.fillMaxWidth(),
-                    )
-                    Spacer(modifier = Modifier.height(12.dp))
-                    q.options.forEach { option ->
-                        val count = counts[option] ?: 0
-                        Row(
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // 実際の回答集計
+            question?.let { q ->
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                    ),
+                ) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Text(
+                            text = q.text,
+                            fontSize = 16.sp,
+                            fontWeight = FontWeight.Medium,
+                            textAlign = TextAlign.Center,
                             modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                        ) {
-                            Text(text = option, fontSize = 16.sp)
-                            Text(
-                                text = "${count}人",
-                                fontSize = 16.sp,
-                                fontWeight = FontWeight.Bold,
-                                color = MaterialTheme.colorScheme.primary,
-                            )
+                        )
+                        Spacer(modifier = Modifier.height(12.dp))
+                        q.options.forEach { option ->
+                            val count = counts[option] ?: 0
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                            ) {
+                                Text(text = option, fontSize = 16.sp)
+                                Text(
+                                    text = "${count}人",
+                                    fontSize = 16.sp,
+                                    fontWeight = FontWeight.Bold,
+                                    color = MaterialTheme.colorScheme.primary,
+                                )
+                            }
+                            Spacer(modifier = Modifier.height(4.dp))
                         }
-                        Spacer(modifier = Modifier.height(4.dp))
                     }
                 }
             }
-        }
 
-        Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(16.dp))
 
-        // 自分のスコア
-        myScore?.let { score ->
-            Card(
-                modifier = Modifier.fillMaxWidth(),
-                colors = CardDefaults.cardColors(
-                    containerColor = if (score.roundScore == 100)
-                        MaterialTheme.colorScheme.primaryContainer
-                    else MaterialTheme.colorScheme.surfaceVariant,
-                ),
-            ) {
-                Column(
-                    modifier = Modifier.padding(16.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally,
+            // 自分のスコア
+            myScore?.let { score ->
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = CardDefaults.cardColors(
+                        containerColor = if (score.roundScore == 100)
+                            MaterialTheme.colorScheme.primaryContainer
+                        else MaterialTheme.colorScheme.surfaceVariant,
+                    ),
                 ) {
-                    if (score.roundScore == 100) Text("🎯 パーフェクト！", fontSize = 18.sp)
-                    Text(
-                        text = "あなたの予測: ${score.targetOption} が ${score.predictedCount}人",
-                        fontSize = 14.sp,
-                    )
-                    Text(
-                        text = "実際: ${score.actualCount}人",
-                        fontSize = 14.sp,
-                    )
-                    Text(
-                        text = "+${score.roundScore}点",
-                        fontSize = 28.sp,
-                        fontWeight = FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.primary,
-                    )
+                    Column(
+                        modifier = Modifier.padding(16.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        if (score.roundScore == 100) Text("🎯 パーフェクト！", fontSize = 18.sp)
+                        Text(
+                            text = "あなたの予測: ${score.targetOption} が ${score.predictedCount}人",
+                            fontSize = 14.sp,
+                        )
+                        Text(
+                            text = "実際: ${score.actualCount}人",
+                            fontSize = 14.sp,
+                        )
+                        Text(
+                            text = "+${score.roundScore}点",
+                            fontSize = 28.sp,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                    }
                 }
             }
-        }
 
-        Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(16.dp))
 
-        Text(
-            text = "ランキング",
-            fontSize = 18.sp,
-            fontWeight = FontWeight.Bold,
-        )
+            Text(
+                text = "ランキング",
+                fontSize = 18.sp,
+                fontWeight = FontWeight.Bold,
+            )
 
-        LazyColumn(
-            modifier = Modifier.weight(1f),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            itemsIndexed(uiState.scores) { index, score ->
-                RankingRow(rank = index + 1, score = score, myPlayerId = uiState.playerId)
+            LazyColumn(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                itemsIndexed(uiState.scores) { index, score ->
+                    RankingRow(rank = index + 1, score = score, myPlayerId = uiState.playerId)
+                }
             }
-        }
 
-        Spacer(modifier = Modifier.height(8.dp))
-        Text(
-            text = "次のラウンドに自動で進みます...",
-            fontSize = 13.sp,
-            color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f),
-        )
-        Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "次のラウンドに自動で進みます...",
+                fontSize = 13.sp,
+                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f),
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+        }
     }
 }
 

--- a/android/app/src/main/java/com/rokusoudo/hitokazu/ui/screens/WaitingRoomScreen.kt
+++ b/android/app/src/main/java/com/rokusoudo/hitokazu/ui/screens/WaitingRoomScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.rokusoudo.hitokazu.data.model.GamePhase
+import com.rokusoudo.hitokazu.ui.components.ConnectionBanner
 import com.rokusoudo.hitokazu.viewmodel.GameViewModel
 
 @Composable
@@ -27,83 +28,90 @@ fun WaitingRoomScreen(
         }
     }
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(24.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        Spacer(modifier = Modifier.height(24.dp))
-
-        Text(text = "待合室", fontSize = 28.sp, fontWeight = FontWeight.Bold)
-
-        Text(
-            text = "ルームID: ${uiState.roomId}",
-            fontSize = 20.sp,
-            color = MaterialTheme.colorScheme.primary,
-            modifier = Modifier.padding(top = 8.dp),
+    Column(modifier = Modifier.fillMaxSize()) {
+        ConnectionBanner(
+            isDisconnected = uiState.isDisconnected,
+            onReconnect = { viewModel.reconnect() },
         )
 
-        // 接続状態（Firebase自動管理）
-        Text(
-            text = "Firebase接続中",
-            fontSize = 12.sp,
-            color = MaterialTheme.colorScheme.primary,
-            modifier = Modifier.padding(top = 4.dp, bottom = 24.dp),
-        )
-
-        Text(
-            text = "参加者 (${uiState.players.size}人)",
-            fontSize = 18.sp,
-            fontWeight = FontWeight.Medium,
-        )
-
-        LazyColumn(
+        Column(
             modifier = Modifier
-                .weight(1f)
-                .fillMaxWidth()
-                .padding(top = 8.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+                .fillMaxSize()
+                .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            items(uiState.players) { player ->
-                Card(
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    Row(
-                        modifier = Modifier.padding(16.dp),
-                        verticalAlignment = Alignment.CenterVertically,
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Text(text = "待合室", fontSize = 28.sp, fontWeight = FontWeight.Bold)
+
+            Text(
+                text = "ルームID: ${uiState.roomId}",
+                fontSize = 20.sp,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(top = 8.dp),
+            )
+
+            // 接続状態（Firebase自動管理）
+            Text(
+                text = "Firebase接続中",
+                fontSize = 12.sp,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(top = 4.dp, bottom = 24.dp),
+            )
+
+            Text(
+                text = "参加者 (${uiState.players.size}人)",
+                fontSize = 18.sp,
+                fontWeight = FontWeight.Medium,
+            )
+
+            LazyColumn(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .padding(top = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                items(uiState.players) { player ->
+                    Card(
+                        modifier = Modifier.fillMaxWidth(),
                     ) {
-                        Text(
-                            text = player.nickname,
-                            fontSize = 16.sp,
-                            modifier = Modifier.weight(1f),
-                        )
-                        if (player.isHost) {
-                            Surface(
-                                color = MaterialTheme.colorScheme.primaryContainer,
-                                shape = MaterialTheme.shapes.small,
-                            ) {
-                                Text(
-                                    text = "ホスト",
-                                    fontSize = 12.sp,
-                                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
-                                )
+                        Row(
+                            modifier = Modifier.padding(16.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Text(
+                                text = player.nickname,
+                                fontSize = 16.sp,
+                                modifier = Modifier.weight(1f),
+                            )
+                            if (player.isHost) {
+                                Surface(
+                                    color = MaterialTheme.colorScheme.primaryContainer,
+                                    shape = MaterialTheme.shapes.small,
+                                ) {
+                                    Text(
+                                        text = "ホスト",
+                                        fontSize = 12.sp,
+                                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                                    )
+                                }
                             }
                         }
                     }
                 }
             }
-        }
 
-        Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(16.dp))
 
-        if (!uiState.isHost) {
-            Text(
-                text = "ホストがゲームを開始するまでお待ちください",
-                fontSize = 14.sp,
-                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
-                modifier = Modifier.padding(bottom = 24.dp),
-            )
+            if (!uiState.isHost) {
+                Text(
+                    text = "ホストがゲームを開始するまでお待ちください",
+                    fontSize = 14.sp,
+                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+                    modifier = Modifier.padding(bottom = 24.dp),
+                )
+            }
         }
     }
 }

--- a/android/app/src/main/java/com/rokusoudo/hitokazu/viewmodel/GameViewModel.kt
+++ b/android/app/src/main/java/com/rokusoudo/hitokazu/viewmodel/GameViewModel.kt
@@ -4,6 +4,8 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.rokusoudo.hitokazu.data.firebase.FirebaseRepository
+import com.rokusoudo.hitokazu.data.firebase.PlayersEvent
+import com.rokusoudo.hitokazu.data.firebase.RoomEvent
 import com.rokusoudo.hitokazu.data.model.*
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -27,10 +29,16 @@ data class GameUiState(
     val isLoading: Boolean = false,
     val pendingJoinRoomId: String? = null,
     val selectedCategory: QuestionCategory = QuestionCategory.ALL,
+    // Firestoreとの接続が切れている（と判定された）状態。ConnectionBannerの表示制御に使う（Issue #18）。
+    val isDisconnected: Boolean = false,
 )
 
 // 回答・予測フェーズのタイムアウト猶予秒数（通信遅延・端末クロックのズレを吸収するバッファ）
 private const val TIMEOUT_GRACE_SECONDS = 3
+
+// snapshotがキャッシュ由来のまま連続した場合に「切断」とみなすまでの猶予（ミリ秒）。
+// 代表確認済み: 5秒固定。調整する場合はこの定数のみを変更すればよい（Issue #18）。
+private const val DISCONNECT_THRESHOLD_MS = 5_000L
 
 class GameViewModel : ViewModel() {
 
@@ -47,6 +55,39 @@ class GameViewModel : ViewModel() {
     // 直近でタイムアウト監視をスケジュールした（フェーズ, ラウンド, フェーズ開始時刻）の組。
     // 同じ組に対して重複してタイマーを仕込まないようにするためのガード。
     private var lastScheduledTimeoutKey: String? = null
+
+    // ── 接続状態の監視（Issue #18） ───────────────────────────
+    // room / players それぞれのリスナーについて、キャッシュ由来のデータが
+    // DISCONNECT_THRESHOLD_MS 続いたら「切断」とみなすためのタイマー。
+    private var roomCacheTimeoutJob: Job? = null
+    private var playersCacheTimeoutJob: Job? = null
+
+    // 切断と判定されているソース（"room" / "players"）の集合。
+    // 空であれば isDisconnected = false。どちらか一方でも切断中ならバナーを表示する。
+    private val disconnectedSources = mutableSetOf<String>()
+
+    private fun markSourceDisconnected(source: String) {
+        if (disconnectedSources.add(source)) {
+            _uiState.update { it.copy(isDisconnected = true) }
+        }
+    }
+
+    private fun markSourceConnected(source: String) {
+        if (disconnectedSources.remove(source)) {
+            _uiState.update { it.copy(isDisconnected = disconnectedSources.isNotEmpty()) }
+        }
+    }
+
+    // isFromCacheな更新を受けるたびに呼ぶ。「キャッシュ由来が5秒続いたら切断」という
+    // 仕様なので、すでに計測中のタイマーがあればそれを流用し、キャッシュ由来の更新が
+    // 連続するたびに5秒を数え直す（＝ずっと切断判定に到達しない）ことを避ける。
+    private fun scheduleCacheTimeout(source: String, existingJob: Job?): Job {
+        if (existingJob?.isActive == true) return existingJob
+        return viewModelScope.launch {
+            delay(DISCONNECT_THRESHOLD_MS)
+            markSourceDisconnected(source)
+        }
+    }
 
     // ── ルーム作成（ホスト） ──────────────────────────────────
     fun createRoom(hostName: String, category: QuestionCategory = QuestionCategory.ALL) {
@@ -131,55 +172,82 @@ class GameViewModel : ViewModel() {
 
     // ── Firestoreリアルタイム監視 ─────────────────────────────
     private fun startObserving(roomId: String) {
+        // リスナーの張り直し（reconnect含む）のたびに、古い接続監視タイマーも
+        // 引き継がず作り直す。引き継ぐと張り直し直後に古いタイマーが誤発火しうる。
+        roomCacheTimeoutJob?.cancel()
+        roomCacheTimeoutJob = null
+        playersCacheTimeoutJob?.cancel()
+        playersCacheTimeoutJob = null
+
         roomObserverJob?.cancel()
         roomObserverJob = viewModelScope.launch {
-            repo.observeRoom(roomId).collect { snapshot ->
-                _uiState.update { state ->
-                    state.copy(
-                        phase = snapshot.status,
-                        currentRound = snapshot.currentRound,
-                        totalRounds = snapshot.totalRounds,
-                        currentQuestion = snapshot.currentQuestion,
-                        answerCounts = snapshot.answerCounts,
-                        scores = when (snapshot.status) {
-                            GamePhase.FINISHED -> snapshot.finalScores
-                            else -> snapshot.roundScores
-                        },
-                        selectedAnswer = if (snapshot.status == GamePhase.ANSWERING &&
-                            snapshot.currentRound != state.currentRound
-                        ) "" else state.selectedAnswer,
-                    )
-                }
+            repo.observeRoom(roomId).collect { event ->
+                when (event) {
+                    is RoomEvent.Error -> {
+                        // Logcatへの出力はFirebaseRepository側で実施済み。
+                        // ここではUiState経由でバナー表示に反映する。
+                        roomCacheTimeoutJob?.cancel()
+                        roomCacheTimeoutJob = null
+                        markSourceDisconnected("room")
+                    }
+                    is RoomEvent.Data -> {
+                        val snapshot = event.snapshot
+                        if (event.isFromCache) {
+                            roomCacheTimeoutJob = scheduleCacheTimeout("room", roomCacheTimeoutJob)
+                        } else {
+                            roomCacheTimeoutJob?.cancel()
+                            roomCacheTimeoutJob = null
+                            markSourceConnected("room")
+                        }
 
-                // ホストがRESULTを検知したら10秒後に次ラウンドへ自動進行
-                if (snapshot.status == GamePhase.RESULT && _uiState.value.isHost) {
-                    autoAdvanceJob?.cancel()
-                    autoAdvanceJob = viewModelScope.launch {
-                        delay(10_000)
-                        repo.advanceToNextRound(roomId)
-                            .onFailure { Log.e("GameViewModel", "advanceToNextRound failed", it) }
-                    }
-                }
+                        _uiState.update { state ->
+                            state.copy(
+                                phase = snapshot.status,
+                                currentRound = snapshot.currentRound,
+                                totalRounds = snapshot.totalRounds,
+                                currentQuestion = snapshot.currentQuestion,
+                                answerCounts = snapshot.answerCounts,
+                                scores = when (snapshot.status) {
+                                    GamePhase.FINISHED -> snapshot.finalScores
+                                    else -> snapshot.roundScores
+                                },
+                                selectedAnswer = if (snapshot.status == GamePhase.ANSWERING &&
+                                    snapshot.currentRound != state.currentRound
+                                ) "" else state.selectedAnswer,
+                            )
+                        }
 
-                // ホスト端末が回答・予測フェーズのタイムアウトを監視する。
-                // 1人でも未提出のままタイマーが尽きると、提出済み分だけでフェーズを強制確定する。
-                when (snapshot.status) {
-                    GamePhase.ANSWERING -> {
-                        predictingTimeoutJob?.cancel()
-                        predictingTimeoutJob = null
-                        scheduleAnsweringTimeout(roomId, snapshot)
-                    }
-                    GamePhase.PREDICTING -> {
-                        answeringTimeoutJob?.cancel()
-                        answeringTimeoutJob = null
-                        schedulePredictingTimeout(roomId, snapshot)
-                    }
-                    else -> {
-                        answeringTimeoutJob?.cancel()
-                        predictingTimeoutJob?.cancel()
-                        answeringTimeoutJob = null
-                        predictingTimeoutJob = null
-                        lastScheduledTimeoutKey = null
+                        // ホストがRESULTを検知したら10秒後に次ラウンドへ自動進行
+                        if (snapshot.status == GamePhase.RESULT && _uiState.value.isHost) {
+                            autoAdvanceJob?.cancel()
+                            autoAdvanceJob = viewModelScope.launch {
+                                delay(10_000)
+                                repo.advanceToNextRound(roomId)
+                                    .onFailure { Log.e("GameViewModel", "advanceToNextRound failed", it) }
+                            }
+                        }
+
+                        // ホスト端末が回答・予測フェーズのタイムアウトを監視する。
+                        // 1人でも未提出のままタイマーが尽きると、提出済み分だけでフェーズを強制確定する。
+                        when (snapshot.status) {
+                            GamePhase.ANSWERING -> {
+                                predictingTimeoutJob?.cancel()
+                                predictingTimeoutJob = null
+                                scheduleAnsweringTimeout(roomId, snapshot)
+                            }
+                            GamePhase.PREDICTING -> {
+                                answeringTimeoutJob?.cancel()
+                                answeringTimeoutJob = null
+                                schedulePredictingTimeout(roomId, snapshot)
+                            }
+                            else -> {
+                                answeringTimeoutJob?.cancel()
+                                predictingTimeoutJob?.cancel()
+                                answeringTimeoutJob = null
+                                predictingTimeoutJob = null
+                                lastScheduledTimeoutKey = null
+                            }
+                        }
                     }
                 }
             }
@@ -187,8 +255,24 @@ class GameViewModel : ViewModel() {
 
         playerObserverJob?.cancel()
         playerObserverJob = viewModelScope.launch {
-            repo.observePlayers(roomId).collect { players ->
-                _uiState.update { it.copy(players = players) }
+            repo.observePlayers(roomId).collect { event ->
+                when (event) {
+                    is PlayersEvent.Error -> {
+                        playersCacheTimeoutJob?.cancel()
+                        playersCacheTimeoutJob = null
+                        markSourceDisconnected("players")
+                    }
+                    is PlayersEvent.Data -> {
+                        if (event.isFromCache) {
+                            playersCacheTimeoutJob = scheduleCacheTimeout("players", playersCacheTimeoutJob)
+                        } else {
+                            playersCacheTimeoutJob?.cancel()
+                            playersCacheTimeoutJob = null
+                            markSourceConnected("players")
+                        }
+                        _uiState.update { it.copy(players = event.players) }
+                    }
+                }
             }
         }
     }
@@ -241,13 +325,30 @@ class GameViewModel : ViewModel() {
         predictingTimeoutJob?.cancel()
         roomObserverJob?.cancel()
         playerObserverJob?.cancel()
+        roomCacheTimeoutJob?.cancel()
+        playersCacheTimeoutJob?.cancel()
+        roomCacheTimeoutJob = null
+        playersCacheTimeoutJob = null
+        disconnectedSources.clear()
         lastScheduledTimeoutKey = null
         _uiState.value = GameUiState()
     }
 
     fun clearError() = _uiState.update { it.copy(errorMessage = null) }
 
-    fun reconnect() {}
+    // ── 再接続（ConnectionBannerの「再接続」ボタンから呼び出す） ──
+    // Firestoreのネットワークを明示的に有効化しつつ、room/playersリスナーを
+    // 張り直す。切断中に進んだルーム状態は、張り直し後の最新snapshotで反映される。
+    fun reconnect() {
+        val roomId = _uiState.value.roomId
+        if (roomId.isEmpty()) return
+
+        viewModelScope.launch {
+            repo.enableNetwork()
+                .onFailure { Log.e("GameViewModel", "enableNetwork failed", it) }
+        }
+        startObserving(roomId)
+    }
 
     // ── ディープリンクから受け取ったルームIDをセット ──────────
     fun setPendingJoinRoomId(roomId: String) {
@@ -265,5 +366,7 @@ class GameViewModel : ViewModel() {
         predictingTimeoutJob?.cancel()
         roomObserverJob?.cancel()
         playerObserverJob?.cancel()
+        roomCacheTimeoutJob?.cancel()
+        playersCacheTimeoutJob?.cancel()
     }
 }


### PR DESCRIPTION
Closes #18

## 背景

`ConnectionBanner` は実装済みだったが、`AnsweringScreen` / `PredictingScreen` の両方が `isDisconnected = false` をリテラルで渡しており、実行時には絶対に表示されない状態だった。加えて `GameViewModel.reconnect()` は空実装、`FirebaseRepository` の2つの `addSnapshotListener` は `error` を握りつぶしログにも出力していなかった。

## 変更内容

### `FirebaseRepository.kt`
- `observeRoom()` / `observePlayers()` の戻り値を `Flow<RoomSnapshot>` / `Flow<List<Player>>` から、データ更新とエラーを区別できる `sealed class`（`RoomEvent` / `PlayersEvent`）に変更
  - `Data(snapshot/players, isFromCache)` … `snapshot.metadata.isFromCache` を伝搬
  - `Error(throwable)` … `error` はもみ消さず `Log.e` で出力しつつ通知
- 両リスナーとも `addSnapshotListener(MetadataChanges.INCLUDE) { ... }` に変更。**これが無いとデータ自体に変化のないメタデータのみの遷移（オンライン⇔オフライン）ではコールバックが一切呼ばれず切断検知ができない**ため必須（advisorレビューで指摘・修正）
- `enableNetwork(): Result<Unit>` を追加（`reconnect()` から呼び出す）

### `GameViewModel.kt`
- `GameUiState` に `isDisconnected: Boolean = false` を追加
- `DISCONNECT_THRESHOLD_MS = 5_000L` を定数化（代表確認済みのしきい値。ここ1箇所を変更すれば調整可能）
- room / players それぞれについて、`isFromCache = true` の更新を受けると5秒のタイマーを開始し、5秒経過してもキャッシュ由来のままなら「切断」とみなす（`disconnectedSources` セットで管理、いずれか一方でも切断中なら `isDisconnected = true`）
  - タイマーはキャッシュ由来の更新が連続するたびに数え直さない（`existingJob?.isActive == true` ならそのまま流用）ようにし、「5秒後に切断判定」という仕様どおりに動くようにした
  - `error` を受けた場合は即座に切断扱いにする
  - サーバー由来（`isFromCache = false`）の更新を受けたら即座に「接続中」に戻す
- `reconnect()` を実装。`FirebaseFirestore.enableNetwork()` を呼びつつ `startObserving()` でroom/playersリスナーを張り直す。張り直し後の最新snapshotで、切断中に進んだルーム状態が画面に反映される
- `resetGame()` / `onCleared()` で新規追加したタイマーJobも解放するよう修正

### 画面側
- `AnsweringScreen.kt` / `PredictingScreen.kt`: `ConnectionBanner(isDisconnected = false, ...)` のリテラルを `uiState.isDisconnected` に差し替え
- `WaitingRoomScreen.kt` / `ResultScreen.kt` / `FinishedScreen.kt`: 表示方針統一のため `ConnectionBanner` を追加（後述）

## 表示方針の統一（Issue本文の論点6）

Firestoreリスナーはルーム参加後（待合室）からゲーム終了まで張られ続けており、どの画面にいても通信断は起こりうる。パーティー会場での利用を想定する以上「フリーズしたと誤認するリスク」はどの画面でも同じなので、**ルーム参加後のすべての画面（待合室・回答・予測・結果・終了）に `ConnectionBanner` を統一表示**する方針とした。ホーム画面・QR表示・QRスキャン画面はリスナーが張られる前なので対象外。

なお `WaitingRoomScreen.kt` には元々「Firebase接続中」という固定テキストが残っている（Firestoreの実際の接続状態を反映しない静的表示）。今回のスコープでは触れていない。バナーと矛盾しうる表示なので、別Issueでの整理を推奨する。

## テスト

自動検証のみで、実機・エミュレータでの手動検証（機内モードでの接続断・復帰）は**未実施**（本タスクは無人実行で実機/エミュレータを操作できないため）。

- `cd android && ./gradlew compileDebugKotlin` → **BUILD SUCCESSFUL**（変更前後の両方で確認。ベースラインでも成功することを先に確認した上で、実装後も成功）
- `python3 backend/test_logic.py`（`unittest`）→ 全テスト合格（本PRはbackendを変更していないが、既存ロジックへの影響がないことの確認として実行）
- ユニットテスト未追加: `android/app/src/main/java` 配下に既存のテストディレクトリ（`test/` / `androidTest/`）が存在せず、テストランナー未整備のプロジェクトのため、今回も新規追加していない（既存の技術的負債。必要であれば別Issue化を推奨）

### 未実施の手動検証手順（実機/エミュレータ担当者向け）

1. Androidエミュレータ or 実機でルームを作成 or 参加し、回答画面 or 予測画面まで進める
2. 機内モードON（または「Extended Controls → Cellular → None」等でネットワーク切断）
3. 5秒以上待ち、「接続が切れました」バナーが表示されることを確認
4. Logcatに `FirebaseRepository` タグのエラーログが出ていないか（意図的な切断なので出ない可能性が高い）、`observeRoom`/`observePlayers` 経由の切断検知ログではなく `isFromCache` ベースの検知であることを確認
5. 機内モードOFF（通信復帰）
6. バナーが自動的に消えることを確認
7. 切断中にホスト端末側でラウンドが進んでいた場合、バナー消灯と同時にルーム状態（現在の質問・フェーズ等）が最新化されることを確認
8. 再度機内モードにし、バナーが出た状態で「再接続」ボタンを押す→機内モードのままでは接続は戻らないことを確認した上で、機内モードを解除し、再接続ボタン経由でリスナーが張り直っても正しく最新状態を受信できることを確認

## 受け入れ基準チェックリスト

- [ ] 端末を機内モードにすると、回答画面・予測画面に「接続が切れました」バナーが表示される — **実機/エミュレータでの検証は未実施**。ロジック上は`isFromCache`が5秒継続すると`isDisconnected=true`になるよう実装済み
- [ ] 通信を復帰させるとバナーが自動的に消える — **未実施**。ロジック上はサーバー由来のsnapshotを受信した時点で即座に`isDisconnected=false`に戻る実装
- [ ] バナーの「再接続」ボタンを押すとリスナーが張り直され、切断中に進んだルーム状態が画面に反映される — **未実施**。`reconnect()`が`enableNetwork()`＋`startObserving()`（リスナー再アタッチ）を行う実装
- [x] snapshot listener のエラーが握りつぶされず、少なくとも Logcat に出力される — `FirebaseRepository`側で`Log.e`出力を確認（コードレビューで確認、実機ログは未取得）
- [x] `isDisconnected` を UiState 経由で制御しており、画面側にリテラル `false` が残っていない — `grep`で確認済み
- [x] 接続断・復帰の手動検証手順と結果が PR に記載されている — 本セクションに記載（結果は「未実施」）

## 対応できなかった点

- 実機・エミュレータでの手動検証（機内モードでの接続断・復帰の実地確認）は、本タスクが無人実行で実機/エミュレータを操作できないため未実施。上記の手順に沿ってレビュー担当者様に実施いただくことを推奨する
- `WaitingRoomScreen.kt` の「Firebase接続中」固定テキストはスコープ外として残置（別issue化を推奨）
